### PR TITLE
Add network topology related features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ dist
 **/.DS_Store
 out.txt
 
+node_modules/
+
 *.sublime-*
+.omega.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 
 *.sublime-*
 .omega.json
+.vite

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 main
-*.json
 .idea
 cover.out
 tmtop

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
+FRONT_DIR = pkg/topology/embed/frontend
 LDFLAGS = -X main.version=${VERSION}
 
-build:
+build: build-front build-go
+
+build-front:
+	pnpm -C $(FRONT_DIR) install
+	pnpm -C $(FRONT_DIR) run build
+
+build-go:
 	go build -ldflags '$(LDFLAGS)' cmd/tmtop.go
 
 install:

--- a/cmd/tmtop.go
+++ b/cmd/tmtop.go
@@ -59,6 +59,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&config.Timezone, "timezone", "", "Timezone to display dates in")
 	rootCmd.PersistentFlags().BoolVar(&config.WithTopologyAPI, "with-topology-api", false, "Enable topology API")
 	rootCmd.PersistentFlags().StringVar(&config.TopologyListenAddr, "topology-listen-addr", "0.0.0.0:8080", "The address on which to serve topology API")
+	rootCmd.PersistentFlags().StringSliceVar(&config.TopologyHighlightNodes, "topology-highlight-nodes", nil, "The nodes to highlight in the produced topology graph, either by moniker or IP address")
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.GetDefaultLogger().Fatal().Err(err).Msg("Could not start application")

--- a/cmd/tmtop.go
+++ b/cmd/tmtop.go
@@ -57,6 +57,8 @@ func main() {
 	rootCmd.PersistentFlags().Int64Var(&config.HaltHeight, "halt-height", 0, "Custom halt-height")
 	rootCmd.PersistentFlags().Uint64Var(&config.BlocksBehind, "blocks-behind", 1000, "How many blocks behind to check to calculate block time")
 	rootCmd.PersistentFlags().StringVar(&config.Timezone, "timezone", "", "Timezone to display dates in")
+	rootCmd.PersistentFlags().BoolVar(&config.WithTopologyAPI, "with-topology-api", false, "Enable topology API")
+	rootCmd.PersistentFlags().StringVar(&config.TopologyListenAddr, "topology-listen-addr", "0.0.0.0:8080", "The address on which to serve topology API")
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.GetDefaultLogger().Fatal().Err(err).Msg("Could not start application")

--- a/cmd/tmtop.go
+++ b/cmd/tmtop.go
@@ -60,7 +60,6 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&config.Timezone, "timezone", "", "Timezone to display dates in")
 	rootCmd.PersistentFlags().BoolVar(&config.WithTopologyAPI, "with-topology-api", false, "Enable topology API")
 	rootCmd.PersistentFlags().StringVar(&config.TopologyListenAddr, "topology-listen-addr", "0.0.0.0:8080", "The address on which to serve topology API")
-	rootCmd.PersistentFlags().StringSliceVar(&config.TopologyHighlightNodes, "topology-highlight-nodes", nil, "The nodes to highlight in the produced topology graph, either by node id, IP address or moniker")
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.GetDefaultLogger().Fatal().Err(err).Msg("Could not start application")

--- a/cmd/tmtop.go
+++ b/cmd/tmtop.go
@@ -59,7 +59,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&config.Timezone, "timezone", "", "Timezone to display dates in")
 	rootCmd.PersistentFlags().BoolVar(&config.WithTopologyAPI, "with-topology-api", false, "Enable topology API")
 	rootCmd.PersistentFlags().StringVar(&config.TopologyListenAddr, "topology-listen-addr", "0.0.0.0:8080", "The address on which to serve topology API")
-	rootCmd.PersistentFlags().StringSliceVar(&config.TopologyHighlightNodes, "topology-highlight-nodes", nil, "The nodes to highlight in the produced topology graph, either by moniker or IP address")
+	rootCmd.PersistentFlags().StringSliceVar(&config.TopologyHighlightNodes, "topology-highlight-nodes", nil, "The nodes to highlight in the produced topology graph, either by node id, IP address or moniker")
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.GetDefaultLogger().Fatal().Err(err).Msg("Could not start application")

--- a/cmd/tmtop.go
+++ b/cmd/tmtop.go
@@ -27,6 +27,7 @@ func Execute(inputConfig configPkg.InputConfig, args []string) {
 
 	app := pkg.NewApp(config, version)
 	app.Start()
+	// select {}
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.1
 
 require (
 	cosmossdk.io/x/upgrade v0.1.4
-	github.com/brynbellomy/go-utils v0.0.0-20241104013030-c57db69f0fd6
+	github.com/brynbellomy/go-utils v0.0.0-20241122210636-76465f825743
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/cometbft/cometbft v0.38.11
 	github.com/cosmos/cosmos-sdk v0.50.9
@@ -131,7 +131,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/rs/cors v1.11.0 // indirect
+	github.com/rs/cors v1.11.1 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,12 @@ require (
 	github.com/cosmos/cosmos-sdk v0.50.9
 	github.com/cosmos/interchain-security/v6 v6.1.0
 	github.com/gdamore/tcell/v2 v2.6.0
+	github.com/gorilla/mux v1.8.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/rivo/tview v0.0.0-20231022175332-f7f32ad28104
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
+	gonum.org/v1/gonum v0.12.0
 )
 
 require (
@@ -86,7 +88,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,10 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 h1:41iFGWnSlI2
 github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bits-and-blooms/bitset v1.8.0 h1:FD+XqgOZDUxxZ8hzoBFuV9+cGWY9CslN6d5MS5JVb4c=
 github.com/bits-and-blooms/bitset v1.8.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/brynbellomy/go-utils v0.0.0-20241104013030-c57db69f0fd6 h1:A6AV7h83MP3OdO+9WcnSDOBdf923pJ9d0aWVtbqba/c=
-github.com/brynbellomy/go-utils v0.0.0-20241104013030-c57db69f0fd6/go.mod h1:nqSUwdZrKkc5BuR0+5hCwAN6Z8QzyYCFteGXOaYt7Tw=
+github.com/brynbellomy/go-utils v0.0.0-20241122202042-a706f4bbd004 h1:/dliHkqtbh+Fzpdru0ljoY4WU41DjRg12lqs0RxMM5U=
+github.com/brynbellomy/go-utils v0.0.0-20241122202042-a706f4bbd004/go.mod h1:nqSUwdZrKkc5BuR0+5hCwAN6Z8QzyYCFteGXOaYt7Tw=
+github.com/brynbellomy/go-utils v0.0.0-20241122210636-76465f825743 h1:d4QqUhBGHbz+rPq3FG+76JEYYo+zOjspWM9er9U+Qto=
+github.com/brynbellomy/go-utils v0.0.0-20241122210636-76465f825743/go.mod h1:nqSUwdZrKkc5BuR0+5hCwAN6Z8QzyYCFteGXOaYt7Tw=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
@@ -679,8 +681,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
-github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 h1:41iFGWnSlI2
 github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bits-and-blooms/bitset v1.8.0 h1:FD+XqgOZDUxxZ8hzoBFuV9+cGWY9CslN6d5MS5JVb4c=
 github.com/bits-and-blooms/bitset v1.8.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/brynbellomy/go-utils v0.0.0-20241122202042-a706f4bbd004 h1:/dliHkqtbh+Fzpdru0ljoY4WU41DjRg12lqs0RxMM5U=
-github.com/brynbellomy/go-utils v0.0.0-20241122202042-a706f4bbd004/go.mod h1:nqSUwdZrKkc5BuR0+5hCwAN6Z8QzyYCFteGXOaYt7Tw=
 github.com/brynbellomy/go-utils v0.0.0-20241122210636-76465f825743 h1:d4QqUhBGHbz+rPq3FG+76JEYYo+zOjspWM9er9U+Qto=
 github.com/brynbellomy/go-utils v0.0.0-20241122210636-76465f825743/go.mod h1:nqSUwdZrKkc5BuR0+5hCwAN6Z8QzyYCFteGXOaYt7Tw=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=

--- a/go.sum
+++ b/go.sum
@@ -976,6 +976,8 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
+gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.186.0 h1:n2OPp+PPXX0Axh4GuSsL5QL8xQCTb2oDwyzPnQvqUug=
 google.golang.org/api v0.186.0/go.mod h1:hvRbBmgoje49RV3xqVXrmP6w93n6ehGgIVPYrGtBFFc=

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -72,8 +72,8 @@ func (a *Aggregator) GetChainValidators() (*types.ChainValidators, error) {
 	return a.DataFetcher.GetValidators()
 }
 
-func (a *Aggregator) GetChainInfo() (*types.TendermintStatusResponse, error) {
-	return a.TendermintClient.GetStatus()
+func (a *Aggregator) GetChainInfo(rpcURL string) (*types.TendermintStatusResponse, error) {
+	return a.TendermintClient.GetStatus(rpcURL)
 }
 
 func (a *Aggregator) GetUpgrade() (*types.Upgrade, error) {

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -80,7 +80,7 @@ func (a *App) Start() {
 func (a *App) ServeTopology() {
 	_ = tmhttp.NewServer(
 		a.Config.TopologyListenAddr,
-		topology.WithHTTPTopologyAPI(a.State),
+		topology.WithHTTPTopologyAPI(a.State, a.Config.TopologyHighlightNodes),
 	).Serve()
 }
 
@@ -112,7 +112,7 @@ func (a *App) CrawlRPCURLs() {
 
 					a.State.AddRPCPeers(rpc.URL, netInfo.Peers)
 					for _, peer := range netInfo.Peers {
-						a.mbRPCURLs.Deliver(types.RPC{URL: peer.URL(), Moniker: peer.NodeInfo.Moniker})
+						a.mbRPCURLs.Deliver(types.RPC{IP: peer.RemoteIP, URL: peer.URL(), Moniker: peer.NodeInfo.Moniker})
 					}
 				}()
 			}

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -88,7 +88,8 @@ func (a *App) ServeTopology() {
 }
 
 func (a *App) CrawlRPCURLs() {
-	a.fetchNewPeers(a.Config.RPCHost)
+	a.mbRPCURLs.Deliver(types.RPC{URL: a.Config.RPCHost})
+	// a.fetchNewPeers(a.Config.RPCHost)
 	timer := time.NewTimer(15 * time.Second)
 
 	for {

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -81,7 +81,7 @@ func (a *App) Start() {
 func (a *App) ServeTopology() {
 	_ = tmhttp.NewServer(
 		a.Config.TopologyListenAddr,
-		topology.WithHTTPTopologyAPI(a.State, a.Config.TopologyHighlightNodes),
+		topology.WithHTTPTopologyAPI(a.State),
 		topology.WithHTTPPeersAPI(a.State),
 		topology.WithFrontendStaticAssets(),
 	).Serve()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,24 +7,25 @@ import (
 )
 
 type InputConfig struct {
-	RPCHost               string
-	ProviderRPCHost       string
-	ConsumerID            string
-	RefreshRate           time.Duration
-	ValidatorsRefreshRate time.Duration
-	ChainInfoRefreshRate  time.Duration
-	UpgradeRefreshRate    time.Duration
-	BlockTimeRefreshRate  time.Duration
-	ChainType             string
-	Verbose               bool
-	DisableEmojis         bool
-	DebugFile             string
-	HaltHeight            int64
-	BlocksBehind          uint64
-	LCDHost               string
-	Timezone              string
-	WithTopologyAPI       bool
-	TopologyListenAddr    string
+	RPCHost                string
+	ProviderRPCHost        string
+	ConsumerID             string
+	RefreshRate            time.Duration
+	ValidatorsRefreshRate  time.Duration
+	ChainInfoRefreshRate   time.Duration
+	UpgradeRefreshRate     time.Duration
+	BlockTimeRefreshRate   time.Duration
+	ChainType              string
+	Verbose                bool
+	DisableEmojis          bool
+	DebugFile              string
+	HaltHeight             int64
+	BlocksBehind           uint64
+	LCDHost                string
+	Timezone               string
+	WithTopologyAPI        bool
+	TopologyListenAddr     string
+	TopologyHighlightNodes []string
 }
 
 type ChainType string
@@ -85,48 +86,50 @@ func ParseAndValidateConfig(input InputConfig) (*Config, error) {
 	}
 
 	config := &Config{
-		RPCHost:               input.RPCHost,
-		ProviderRPCHost:       input.ProviderRPCHost,
-		ConsumerID:            input.ConsumerID,
-		RefreshRate:           input.RefreshRate,
-		ValidatorsRefreshRate: input.ValidatorsRefreshRate,
-		ChainInfoRefreshRate:  input.ChainInfoRefreshRate,
-		UpgradeRefreshRate:    input.UpgradeRefreshRate,
-		BlockTimeRefreshRate:  input.BlockTimeRefreshRate,
-		ChainType:             chainType,
-		Verbose:               input.Verbose,
-		DisableEmojis:         input.DisableEmojis,
-		DebugFile:             input.DebugFile,
-		HaltHeight:            input.HaltHeight,
-		BlocksBehind:          input.BlocksBehind,
-		LCDHost:               input.LCDHost,
-		Timezone:              timezone,
-		WithTopologyAPI:       input.WithTopologyAPI,
-		TopologyListenAddr:    input.TopologyListenAddr,
+		RPCHost:                input.RPCHost,
+		ProviderRPCHost:        input.ProviderRPCHost,
+		ConsumerID:             input.ConsumerID,
+		RefreshRate:            input.RefreshRate,
+		ValidatorsRefreshRate:  input.ValidatorsRefreshRate,
+		ChainInfoRefreshRate:   input.ChainInfoRefreshRate,
+		UpgradeRefreshRate:     input.UpgradeRefreshRate,
+		BlockTimeRefreshRate:   input.BlockTimeRefreshRate,
+		ChainType:              chainType,
+		Verbose:                input.Verbose,
+		DisableEmojis:          input.DisableEmojis,
+		DebugFile:              input.DebugFile,
+		HaltHeight:             input.HaltHeight,
+		BlocksBehind:           input.BlocksBehind,
+		LCDHost:                input.LCDHost,
+		Timezone:               timezone,
+		WithTopologyAPI:        input.WithTopologyAPI,
+		TopologyListenAddr:     input.TopologyListenAddr,
+		TopologyHighlightNodes: input.TopologyHighlightNodes,
 	}
 
 	return config, nil
 }
 
 type Config struct {
-	RPCHost               string
-	ProviderRPCHost       string
-	ConsumerID            string
-	RefreshRate           time.Duration
-	ValidatorsRefreshRate time.Duration
-	ChainInfoRefreshRate  time.Duration
-	UpgradeRefreshRate    time.Duration
-	BlockTimeRefreshRate  time.Duration
-	ChainType             ChainType
-	Verbose               bool
-	DisableEmojis         bool
-	DebugFile             string
-	HaltHeight            int64
-	BlocksBehind          uint64
-	LCDHost               string
-	Timezone              *time.Location
-	WithTopologyAPI       bool
-	TopologyListenAddr    string
+	RPCHost                string
+	ProviderRPCHost        string
+	ConsumerID             string
+	RefreshRate            time.Duration
+	ValidatorsRefreshRate  time.Duration
+	ChainInfoRefreshRate   time.Duration
+	UpgradeRefreshRate     time.Duration
+	BlockTimeRefreshRate   time.Duration
+	ChainType              ChainType
+	Verbose                bool
+	DisableEmojis          bool
+	DebugFile              string
+	HaltHeight             int64
+	BlocksBehind           uint64
+	LCDHost                string
+	Timezone               *time.Location
+	WithTopologyAPI        bool
+	TopologyListenAddr     string
+	TopologyHighlightNodes []string
 }
 
 func (c Config) GetProviderOrConsumerHost() string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,8 @@ type InputConfig struct {
 	BlocksBehind          uint64
 	LCDHost               string
 	Timezone              string
+	WithTopologyAPI       bool
+	TopologyListenAddr    string
 }
 
 type ChainType string
@@ -99,6 +101,8 @@ func ParseAndValidateConfig(input InputConfig) (*Config, error) {
 		BlocksBehind:          input.BlocksBehind,
 		LCDHost:               input.LCDHost,
 		Timezone:              timezone,
+		WithTopologyAPI:       input.WithTopologyAPI,
+		TopologyListenAddr:    input.TopologyListenAddr,
 	}
 
 	return config, nil
@@ -121,6 +125,8 @@ type Config struct {
 	BlocksBehind          uint64
 	LCDHost               string
 	Timezone              *time.Location
+	WithTopologyAPI       bool
+	TopologyListenAddr    string
 }
 
 func (c Config) GetProviderOrConsumerHost() string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,25 +7,24 @@ import (
 )
 
 type InputConfig struct {
-	RPCHost                string
-	ProviderRPCHost        string
-	ConsumerID             string
-	RefreshRate            time.Duration
-	ValidatorsRefreshRate  time.Duration
-	ChainInfoRefreshRate   time.Duration
-	UpgradeRefreshRate     time.Duration
-	BlockTimeRefreshRate   time.Duration
-	ChainType              string
-	Verbose                bool
-	DisableEmojis          bool
-	DebugFile              string
-	HaltHeight             int64
-	BlocksBehind           uint64
-	LCDHost                string
-	Timezone               string
-	WithTopologyAPI        bool
-	TopologyListenAddr     string
-	TopologyHighlightNodes []string
+	RPCHost               string
+	ProviderRPCHost       string
+	ConsumerID            string
+	RefreshRate           time.Duration
+	ValidatorsRefreshRate time.Duration
+	ChainInfoRefreshRate  time.Duration
+	UpgradeRefreshRate    time.Duration
+	BlockTimeRefreshRate  time.Duration
+	ChainType             string
+	Verbose               bool
+	DisableEmojis         bool
+	DebugFile             string
+	HaltHeight            int64
+	BlocksBehind          uint64
+	LCDHost               string
+	Timezone              string
+	WithTopologyAPI       bool
+	TopologyListenAddr    string
 }
 
 type ChainType string
@@ -86,50 +85,48 @@ func ParseAndValidateConfig(input InputConfig) (*Config, error) {
 	}
 
 	config := &Config{
-		RPCHost:                input.RPCHost,
-		ProviderRPCHost:        input.ProviderRPCHost,
-		ConsumerID:             input.ConsumerID,
-		RefreshRate:            input.RefreshRate,
-		ValidatorsRefreshRate:  input.ValidatorsRefreshRate,
-		ChainInfoRefreshRate:   input.ChainInfoRefreshRate,
-		UpgradeRefreshRate:     input.UpgradeRefreshRate,
-		BlockTimeRefreshRate:   input.BlockTimeRefreshRate,
-		ChainType:              chainType,
-		Verbose:                input.Verbose,
-		DisableEmojis:          input.DisableEmojis,
-		DebugFile:              input.DebugFile,
-		HaltHeight:             input.HaltHeight,
-		BlocksBehind:           input.BlocksBehind,
-		LCDHost:                input.LCDHost,
-		Timezone:               timezone,
-		WithTopologyAPI:        input.WithTopologyAPI,
-		TopologyListenAddr:     input.TopologyListenAddr,
-		TopologyHighlightNodes: input.TopologyHighlightNodes,
+		RPCHost:               input.RPCHost,
+		ProviderRPCHost:       input.ProviderRPCHost,
+		ConsumerID:            input.ConsumerID,
+		RefreshRate:           input.RefreshRate,
+		ValidatorsRefreshRate: input.ValidatorsRefreshRate,
+		ChainInfoRefreshRate:  input.ChainInfoRefreshRate,
+		UpgradeRefreshRate:    input.UpgradeRefreshRate,
+		BlockTimeRefreshRate:  input.BlockTimeRefreshRate,
+		ChainType:             chainType,
+		Verbose:               input.Verbose,
+		DisableEmojis:         input.DisableEmojis,
+		DebugFile:             input.DebugFile,
+		HaltHeight:            input.HaltHeight,
+		BlocksBehind:          input.BlocksBehind,
+		LCDHost:               input.LCDHost,
+		Timezone:              timezone,
+		WithTopologyAPI:       input.WithTopologyAPI,
+		TopologyListenAddr:    input.TopologyListenAddr,
 	}
 
 	return config, nil
 }
 
 type Config struct {
-	RPCHost                string
-	ProviderRPCHost        string
-	ConsumerID             string
-	RefreshRate            time.Duration
-	ValidatorsRefreshRate  time.Duration
-	ChainInfoRefreshRate   time.Duration
-	UpgradeRefreshRate     time.Duration
-	BlockTimeRefreshRate   time.Duration
-	ChainType              ChainType
-	Verbose                bool
-	DisableEmojis          bool
-	DebugFile              string
-	HaltHeight             int64
-	BlocksBehind           uint64
-	LCDHost                string
-	Timezone               *time.Location
-	WithTopologyAPI        bool
-	TopologyListenAddr     string
-	TopologyHighlightNodes []string
+	RPCHost               string
+	ProviderRPCHost       string
+	ConsumerID            string
+	RefreshRate           time.Duration
+	ValidatorsRefreshRate time.Duration
+	ChainInfoRefreshRate  time.Duration
+	UpgradeRefreshRate    time.Duration
+	BlockTimeRefreshRate  time.Duration
+	ChainType             ChainType
+	Verbose               bool
+	DisableEmojis         bool
+	DebugFile             string
+	HaltHeight            int64
+	BlocksBehind          uint64
+	LCDHost               string
+	Timezone              *time.Location
+	WithTopologyAPI       bool
+	TopologyListenAddr    string
 }
 
 func (c Config) GetProviderOrConsumerHost() string {

--- a/pkg/display/wrapper.go
+++ b/pkg/display/wrapper.go
@@ -275,7 +275,7 @@ func (w *Wrapper) SetState(state *types.State) {
 	w.LastRoundTableData.SetValidators(state.GetValidatorsWithInfo(), state.ConsensusStateError)
 	w.AllRoundsTableData.SetValidators(state.GetValidatorsWithInfoAndAllRoundVotes())
 	w.NetInfoTableData.SetNetInfo(state.NetInfo)
-	w.RPCsTableData.SetKnownRPCs(state.KnownRPCs())
+	w.RPCsTableData.SetKnownRPCs(state.KnownRPCs().Values())
 
 	w.ConsensusInfoTextView.Clear()
 	w.ChainInfoTextView.Clear()

--- a/pkg/display/wrapper.go
+++ b/pkg/display/wrapper.go
@@ -22,7 +22,7 @@ const (
 const (
 	DefaultColumnsCount = 3
 	RowsAmount          = 10
-	DebugBlockHeight    = 2
+	DebugBlockHeight    = 8
 	DefaultMode         = ModeLastRound
 )
 

--- a/pkg/fetcher/cosmos_rpc.go
+++ b/pkg/fetcher/cosmos_rpc.go
@@ -13,10 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	genutilTypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 
@@ -109,12 +105,6 @@ func (f *CosmosRPCDataFetcher) AbciQuery(
 	return output.Unmarshal(response.Result.Response.Value)
 }
 
-func validatorAddr(pubkeyBytes []byte) string {
-	pubkey := secp256k1.PubKey(pubkeyBytes)
-	pubKeyConvertedToAddress := sdk.ValAddress(pubkey.Address().Bytes())
-	return pubKeyConvertedToAddress.String()
-}
-
 func (f *CosmosRPCDataFetcher) ParseValidator(validator stakingTypes.Validator) (types.ChainValidator, error) {
 	if err := validator.UnpackInterfaces(f.ParseCodec); err != nil {
 		return types.ChainValidator{}, err
@@ -126,9 +116,10 @@ func (f *CosmosRPCDataFetcher) ParseValidator(validator stakingTypes.Validator) 
 	}
 
 	return types.ChainValidator{
-		Moniker:    validator.GetMoniker(),
-		Address:    fmt.Sprintf("%X", addr),
-		RawAddress: sdkTypes.ConsAddress(addr).String(),
+		Moniker:         validator.GetMoniker(),
+		Address:         fmt.Sprintf("%X", addr),
+		RawAddress:      sdkTypes.ConsAddress(addr).String(),
+		ConsensusPubkey: validator.ConsensusPubkey.Value,
 	}, nil
 }
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -1,9 +1,10 @@
 package http
 
 import (
-	"github.com/gorilla/mux"
 	"net/http"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 type Server struct {

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+	"time"
+)
+
+type Server struct {
+	server *http.Server
+	router *mux.Router
+}
+
+func NewServer(addr string, opts ...Option) *Server {
+	router := mux.NewRouter()
+	s := &Server{
+		server: &http.Server{
+			Addr:              addr,
+			Handler:           router,
+			ReadHeaderTimeout: 5 * time.Second,
+		},
+		router: router,
+	}
+
+	WithOptions(opts...)(s)
+
+	return s
+}
+
+type Option func(*Server)
+
+func WithOptions(opts ...Option) Option {
+	return func(s *Server) {
+		for _, opt := range opts {
+			opt(s)
+		}
+	}
+}
+
+func WithRouterOption(opt func(*mux.Router)) Option {
+	return func(s *Server) {
+		opt(s.router)
+	}
+}
+
+func WithServerOption(opt func(*http.Server)) Option {
+	return func(s *Server) {
+		opt(s.server)
+	}
+}
+
+func WithRoute(method, path string, handler http.Handler) Option {
+	return WithRouterOption(func(r *mux.Router) {
+		r.Methods(method).Path(path).Handler(handler)
+	})
+}
+
+func (s *Server) Serve() error {
+	return s.server.ListenAndServe()
+}

--- a/pkg/tendermint/tendermint.go
+++ b/pkg/tendermint/tendermint.go
@@ -103,9 +103,11 @@ func (rpc *RPC) GetValidatorsViaDumpConsensusState() ([]types.TendermintValidato
 	return response.Result.RoundState.Validators.Validators, nil
 }
 
-func (rpc *RPC) GetStatus() (*types.TendermintStatusResponse, error) {
+func (rpc *RPC) GetStatus(rpcURL string) (*types.TendermintStatusResponse, error) {
+	client := http.NewClient(rpc.Logger, "tendermint_rpc", rpcURL)
+
 	var response types.TendermintStatusResponse
-	if err := rpc.client().Get("/status", &response); err != nil {
+	if err := client.Get("/status", &response); err != nil {
 		return nil, err
 	}
 

--- a/pkg/topology/embed/embed.go
+++ b/pkg/topology/embed/embed.go
@@ -1,0 +1,8 @@
+package embed
+
+import (
+	"embed"
+)
+
+//go:embed frontend/dist
+var Frontend embed.FS

--- a/pkg/topology/embed/frontend/index.html
+++ b/pkg/topology/embed/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/pkg/topology/embed/frontend/index.html
+++ b/pkg/topology/embed/frontend/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <script>
+        window.global = window
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/pkg/topology/embed/frontend/package.json
+++ b/pkg/topology/embed/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "tmtop-topology",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "graphviz-react": "^1.2.5",
+    "query-string": "^9.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.13.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "eslint": "^9.13.0",
+    "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-refresh": "^0.4.14",
+    "globals": "^15.11.0",
+    "vite": "^5.4.10"
+  }
+}

--- a/pkg/topology/embed/frontend/package.json
+++ b/pkg/topology/embed/frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "graphology": "^0.25.4",
+    "graphology-layout": "^0.6.1",
+    "graphology-layout-forceatlas2": "^0.10.1",
     "graphviz-react": "^1.2.5",
     "query-string": "^9.1.1",
     "react": "^18.3.1",

--- a/pkg/topology/embed/frontend/package.json
+++ b/pkg/topology/embed/frontend/package.json
@@ -13,7 +13,9 @@
     "graphviz-react": "^1.2.5",
     "query-string": "^9.1.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-graph-vis": "^1.0.7",
+    "reagraph": "^4.21.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/pkg/topology/embed/frontend/pnpm-lock.yaml
+++ b/pkg/topology/embed/frontend/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      graphology:
+        specifier: ^0.25.4
+        version: 0.25.4(graphology-types@0.24.8)
+      graphology-layout:
+        specifier: ^0.6.1
+        version: 0.6.1(graphology-types@0.24.8)
+      graphology-layout-forceatlas2:
+        specifier: ^0.10.1
+        version: 0.10.1(graphology-types@0.24.8)
       graphviz-react:
         specifier: ^1.2.5
         version: 1.2.5(react@18.3.1)

--- a/pkg/topology/embed/frontend/pnpm-lock.yaml
+++ b/pkg/topology/embed/frontend/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-graph-vis:
+        specifier: ^1.0.7
+        version: 1.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(react@18.3.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      reagraph:
+        specifier: ^4.21.0
+        version: 4.21.0(@types/three@0.170.0)(graphology-types@0.24.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.13.0
@@ -125,6 +131,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.26.0':
+    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.25.9':
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
     engines: {node: '>=6.9.0'}
@@ -136,6 +146,10 @@ packages:
   '@babel/types@7.26.0':
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
+
+  '@egjs/hammerjs@2.0.17':
+    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
+    engines: {node: '>=0.8.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -347,6 +361,59 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@mediapipe/tasks-vision@0.10.8':
+    resolution: {integrity: sha512-Rp7ll8BHrKB3wXaRFKhrltwZl1CiXGdibPxuWXvqGnKTnv8fqa/nvftYNuSbf+pbJWKYCXdBtYTITdAUTGGh0Q==}
+
+  '@react-spring/animated@9.6.1':
+    resolution: {integrity: sha512-ls/rJBrAqiAYozjLo5EPPLLOb1LM0lNVQcXODTC1SMtS6DbuBCPaKco5svFUQFMP2dso3O+qcC4k9FsKc0KxMQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@react-spring/core@9.6.1':
+    resolution: {integrity: sha512-3HAAinAyCPessyQNNXe5W0OHzRfa8Yo5P748paPcmMowZ/4sMfaZ2ZB6e5x5khQI8NusOHj8nquoutd6FRY5WQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@react-spring/rafz@9.6.1':
+    resolution: {integrity: sha512-v6qbgNRpztJFFfSE3e2W1Uz+g8KnIBs6SmzCzcVVF61GdGfGOuBrbjIcp+nUz301awVmREKi4eMQb2Ab2gGgyQ==}
+
+  '@react-spring/shared@9.6.1':
+    resolution: {integrity: sha512-PBFBXabxFEuF8enNLkVqMC9h5uLRBo6GQhRMQT/nRTnemVENimgRd+0ZT4yFnAQ0AxWNiJfX3qux+bW2LbG6Bw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@react-spring/three@9.6.1':
+    resolution: {integrity: sha512-Tyw2YhZPKJAX3t2FcqvpLRb71CyTe1GvT3V+i+xJzfALgpk10uPGdGaQQ5Xrzmok1340DAeg2pR/MCfaW7b8AA==}
+    peerDependencies:
+      '@react-three/fiber': '>=6.0'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      three: '>=0.126'
+
+  '@react-spring/types@9.6.1':
+    resolution: {integrity: sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q==}
+
+  '@react-three/fiber@8.13.5':
+    resolution: {integrity: sha512-x9QdsaB/Wm/6NGvRXQahPPWfn2dQce7Fg3C2r00NNzyDdqRKw32YavL+WEqjZOOd0nvFpzv7FtaKc+VCOTR59w==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-gl: '>=11.0'
+      react: '>=18.0'
+      react-dom: '>=18.0'
+      react-native: '>=0.64'
+      three: '>=0.133'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.27.3':
     resolution: {integrity: sha512-EzxVSkIvCFxUd4Mgm4xR9YXrcp976qVaHnqom/Tgm+vU79k4vV4eYTjmRvGfeoW8m9LVcsAy/lGjcgVegKEhLQ==}
     cpu: [arm]
@@ -437,6 +504,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -449,11 +519,20 @@ packages:
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
 
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
@@ -461,14 +540,43 @@ packages:
   '@types/react-dom@18.3.1':
     resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
+  '@types/react-reconciler@0.26.7':
+    resolution: {integrity: sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==}
+
+  '@types/react-reconciler@0.28.8':
+    resolution: {integrity: sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==}
+
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
+
+  '@types/stats.js@0.17.3':
+    resolution: {integrity: sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==}
+
+  '@types/three@0.170.0':
+    resolution: {integrity: sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg==}
+
+  '@types/webxr@0.5.20':
+    resolution: {integrity: sha512-JGpU6qiIJQKUuVSKx1GtQnHJGxRjtfGIhzO2ilq43VZZS//f1h1Sgexbdk+Lq+7569a6EYhOWrUpIruR/1Enmg==}
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vitejs/plugin-react@4.3.3':
     resolution: {integrity: sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
+
+  '@webgpu/types@0.1.51':
+    resolution: {integrity: sha512-ktR3u64NPjwIViNCck+z9QeyN0iPkQCUOQ07ZCV1RzlkfP+olLTeEZ95O1QHS+v4w9vJeY9xj/uJuSphsHy5rQ==}
+
+  '@yomguithereal/helpers@1.1.1':
+    resolution: {integrity: sha512-UYvAq/XCA7xoh1juWDYsq3W0WywOB+pz8cgVnE1b45ZfdMhBvHDrgmSFG3jXeZSr2tMTYLGHFHON+ekG05Jebg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -525,6 +633,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -541,12 +652,20 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camera-controls@2.9.0:
+    resolution: {integrity: sha512-TpCujnP0vqPppTXXJRYpvIy0xq9Tro6jQf2iYUxlDpPCNxkvE/XGaTuwIxnhINOkVP/ob2CRYXtY3iVYXeMEzA==}
+    peerDependencies:
+      three: '>=0.126.1'
+
   caniuse-lite@1.0.30001683:
     resolution: {integrity: sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -555,11 +674,19 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -567,6 +694,17 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  ctrl-keys@1.0.3:
+    resolution: {integrity: sha512-Kcb05/xUNra57fxpsLOflECWYbjQEQ9ZuQEthB3cgESN5zMLJ364twA9h2kqz8n06RnTY/+rKWM3UbkOWKeEJg==}
+    engines: {node: '>=10'}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
 
   d3-color@1.4.1:
     resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
@@ -580,20 +718,47 @@ packages:
   d3-ease@1.0.7:
     resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
 
+  d3-force-3d@3.0.5:
+    resolution: {integrity: sha512-tdwhAhoTYZY/a6eo9nR7HP3xSW/C6XvJTbeRpR92nlPzH6OiE+4MliN9feuSFd0tPtEUo+191qOhCTWx3NYifg==}
+    engines: {node: '>=12'}
+
   d3-format@1.4.5:
     resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
 
   d3-graphviz@2.6.1:
     resolution: {integrity: sha512-878AFSagQyr5tTOrM7YiVYeUC2/NoFcOB3/oew+LAML0xekyJSw9j3WOCUMBsc95KYe9XBYZ+SKKuObVya1tJQ==}
 
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
   d3-interpolate@1.4.0:
     resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
+
+  d3-octree@1.0.2:
+    resolution: {integrity: sha512-Qxg4oirJrNXauiuC94uKMbgxwnhdda9xRLl9ihq45srlJ4Ga3CSgqGcAL8iW7N5CIv4Oz8x3E734ulxyvHPvwA==}
 
   d3-path@1.0.9:
     resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
 
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
   d3-selection@1.4.2:
     resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
 
   d3-timer@1.0.10:
     resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
@@ -615,6 +780,9 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
+
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -640,12 +808,21 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  detect-gpu@5.0.58:
+    resolution: {integrity: sha512-LvGBf1NeLMEQhUAHkL+tQPVUxFLU4NWiPWEj35GB9GozOeIc+o9kCj5Zg/sSc795J5TpDty5DVc51y13RI5zkg==}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
+
   electron-to-chromium@1.5.64:
     resolution: {integrity: sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==}
+
+  ellipsize@0.5.1:
+    resolution: {integrity: sha512-0jEAyuIRU6U8MN0S5yUqIrkK/AQWkChh642N3zQuGV57s9bsUWYLc0jJOoDIUkZ2sbEL3ySq8xfq71BvG4q3hw==}
 
   es-abstract@1.23.5:
     resolution: {integrity: sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==}
@@ -750,6 +927,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -758,6 +939,12 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fflate@0.6.10:
+    resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -828,8 +1015,65 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  glodrei@0.0.1:
+    resolution: {integrity: sha512-DMx6ElCSwh1pR4IyDS3LvyFwZHSCCKCqdqo8P1G7klQtqH6PcOjleduCDsHehDtyYQ1E4dzVeoEzHIL1DIxjag==}
+    peerDependencies:
+      '@react-three/fiber': '>=8.0'
+      react: '>=18.0'
+      react-dom: '>=18.0'
+      three: '>=0.137'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+
+  graphology-indices@0.17.0:
+    resolution: {integrity: sha512-A7RXuKQvdqSWOpn7ZVQo4S33O0vCfPBnUSf7FwE0zNCasqwZVUaCXePuWo5HBpWw68KJcwObZDHpFk6HKH6MYQ==}
+    peerDependencies:
+      graphology-types: '>=0.20.0'
+
+  graphology-layout-forceatlas2@0.10.1:
+    resolution: {integrity: sha512-ogzBeF1FvWzjkikrIFwxhlZXvD2+wlY54lqhsrWprcdPjopM2J9HoMweUmIgwaTvY4bUYVimpSsOdvDv1gPRFQ==}
+    peerDependencies:
+      graphology-types: '>=0.19.0'
+
+  graphology-layout-noverlap@0.4.2:
+    resolution: {integrity: sha512-13WwZSx96zim6l1dfZONcqLh3oqyRcjIBsqz2c2iJ3ohgs3605IDWjldH41Gnhh462xGB1j6VGmuGhZ2FKISXA==}
+    peerDependencies:
+      graphology-types: '>=0.19.0'
+
+  graphology-layout@0.6.1:
+    resolution: {integrity: sha512-m9aMvbd0uDPffUCFPng5ibRkb2pmfNvdKjQWeZrf71RS1aOoat5874+DcyNfMeCT4aQguKC7Lj9eCbqZj/h8Ag==}
+    peerDependencies:
+      graphology-types: '>=0.19.0'
+
+  graphology-metrics@2.3.1:
+    resolution: {integrity: sha512-131GRSKUR8DrGkLZSYKM3cwxEg+jqXvv1yLh/KgO0My7BOiuo80r0Qrsnv2N3ZjcOlh8namUS4sSk+cCVnTgKA==}
+    peerDependencies:
+      graphology-types: '>=0.20.0'
+
+  graphology-shortest-path@2.1.0:
+    resolution: {integrity: sha512-KbT9CTkP/u72vGEJzyRr24xFC7usI9Es3LMmCPHGwQ1KTsoZjxwA9lMKxfU0syvT/w+7fZUdB/Hu2wWYcJBm6Q==}
+    peerDependencies:
+      graphology-types: '>=0.20.0'
+
+  graphology-types@0.24.8:
+    resolution: {integrity: sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==}
+
+  graphology-utils@2.5.2:
+    resolution: {integrity: sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==}
+    peerDependencies:
+      graphology-types: '>=0.23.0'
+
+  graphology@0.25.4:
+    resolution: {integrity: sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==}
+    peerDependencies:
+      graphology-types: '>=0.24.0'
 
   graphviz-react@1.2.5:
     resolution: {integrity: sha512-IRFDzEt09hRzfqrrvAW1PAPBqG4t8hykArcoxq7UhEqO5RUKCBN6126D6rjiL2QAwAznbUSg0Fba2RnSH2V4sA==}
@@ -863,6 +1107,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hold-event@0.2.0:
+    resolution: {integrity: sha512-rko5P1XgHzy4B0NR0xVHEpWPgj0i23f8Mf8qsOugd1CHvfLR0PyIyy+8TAQQA9v8qAa1OZ4XuCKk04rxmPGHNQ==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -878,6 +1125,10 @@ packages:
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
@@ -982,6 +1233,11 @@ packages:
     resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
     engines: {node: '>= 0.4'}
 
+  its-fine@1.2.5:
+    resolution: {integrity: sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==}
+    peerDependencies:
+      react: '>=18.0'
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1012,6 +1268,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  keycharm@0.4.0:
+    resolution: {integrity: sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1026,6 +1285,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1033,8 +1295,25 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  mnemonist@0.39.8:
+    resolution: {integrity: sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1078,6 +1357,9 @@ packages:
     resolution: {integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==}
     engines: {node: '>= 0.4'}
 
+  obliterator@2.0.4:
+    resolution: {integrity: sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1089,6 +1371,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  pandemonium@2.4.1:
+    resolution: {integrity: sha512-wRqjisUyiUfXowgm7MFH2rwJzKIr20rca5FsHXCMNm1W5YPP1hCtrZfgmQ62kP7OZ7Xt+cR858aB28lu5NX55g==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1116,6 +1401,9 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1131,29 +1419,73 @@ packages:
     resolution: {integrity: sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==}
     engines: {node: '>=18'}
 
+  react-composer@5.0.3:
+    resolution: {integrity: sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
 
+  react-graph-vis@1.0.7:
+    resolution: {integrity: sha512-FI35zlBMKU22JEvG1ukd1DDwW185y4YrDvHm6Bom9EGdA+UNMrZrIV/lyPIRWPcRkzbKaA1w1NvOYcRApD4KdQ==}
+    peerDependencies:
+      react: '*'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-merge-refs@1.1.0:
+    resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
+
+  react-reconciler@0.27.0:
+    resolution: {integrity: sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^18.0.0
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-use-measure@2.1.1:
+    resolution: {integrity: sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  reagraph@4.21.0:
+    resolution: {integrity: sha512-Hls0BMRY/TznYD7VYyuSM/XJFUoXBYhwbrB3SJCP5cji5GaxKWaDAseBbfiVfSK0hAQLekFW+2gJYQys6kNYiA==}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+
+  reakeys@2.0.3:
+    resolution: {integrity: sha512-5qeGH9xtvFITi+9AyPeTmPhzjDTEBRZICxAg6RJFuEgWFKMHqr6mnMIaL9fgOKJMBzLWCBorpUhyiB824f0EyA==}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   reflect.getprototypeof@1.0.6:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
 
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
   regexp.prototype.flags@1.5.3:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1175,6 +1507,9 @@ packages:
   safe-regex-test@1.0.3:
     resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
     engines: {node: '>= 0.4'}
+
+  scheduler@0.21.0:
+    resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1211,6 +1546,15 @@ packages:
     resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
     engines: {node: '>=12'}
 
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   string.prototype.matchall@4.0.11:
     resolution: {integrity: sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==}
     engines: {node: '>= 0.4'}
@@ -1240,6 +1584,40 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
+  three-mesh-bvh@0.7.6:
+    resolution: {integrity: sha512-rCjsnxEqR9r1/C/lCqzGLS67NDty/S/eT6rAJfDvsanrIctTWdNoR4ZOGWewCB13h1QkVo2BpmC0wakj1+0m8A==}
+    peerDependencies:
+      three: '>= 0.151.0'
+
+  three-stdlib@2.34.0:
+    resolution: {integrity: sha512-U5qJYWgUKBFJqr1coMSbczA964uvouzBjQbtJlaI9LfMwy7hr+kc1Mfh0gqi/2872KmGu9utgff6lj8Oti8+VQ==}
+    peerDependencies:
+      three: '>=0.128.0'
+
+  three@0.154.0:
+    resolution: {integrity: sha512-Uzz8C/5GesJzv8i+Y2prEMYUwodwZySPcNhuJUdsVMH2Yn4Nm8qlbQe6qRN5fOhg55XB0WiLfTPBxVHxpE60ug==}
+
+  troika-three-text@0.47.2:
+    resolution: {integrity: sha512-qylT0F+U7xGs+/PEf3ujBdJMYWbn0Qci0kLqI5BJG2kW1wdg4T1XSxneypnF05DxFqJhEzuaOR9S2SjiyknMng==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.47.2:
+    resolution: {integrity: sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.47.2:
+    resolution: {integrity: sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA==}
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1272,6 +1650,46 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
+
+  uuid@2.0.3:
+    resolution: {integrity: sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
+  vis-data@7.1.9:
+    resolution: {integrity: sha512-COQsxlVrmcRIbZMMTYwD+C2bxYCFDNQ2EHESklPiInbD/Pk3JZ6qNL84Bp9wWjYjAzXfSlsNaFtRk+hO9yBPWA==}
+    peerDependencies:
+      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      vis-util: ^5.0.1
+
+  vis-network@9.1.9:
+    resolution: {integrity: sha512-Ft+hLBVyiLstVYSb69Q1OIQeh3FeUxHJn0WdFcq+BFPqs+Vq1ibMi2sb//cxgq1CP7PH4yOXnHxEH/B2VzpZYA==}
+    peerDependencies:
+      '@egjs/hammerjs': ^2.0.0
+      component-emitter: ^1.3.0
+      keycharm: ^0.2.0 || ^0.3.0 || ^0.4.0
+      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      vis-data: ^6.3.0 || ^7.0.0
+      vis-util: ^5.0.1
+
+  vis-util@5.0.7:
+    resolution: {integrity: sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      '@egjs/hammerjs': ^2.0.0
+      component-emitter: ^1.3.0 || ^2.0.0
 
   vite@5.4.11:
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
@@ -1308,6 +1726,12 @@ packages:
     resolution: {integrity: sha512-W+1+N/hdzLpQZEcvz79n2IgUE9pfx6JLdHh3Kh8RGvLL8P1LdJVQmi2OsDcLdY4QVID4OUy+FPelyerX0nJxIQ==}
     deprecated: 2.x is no longer supported, 3.x published as @viz-js/viz
 
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
+
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
@@ -1338,6 +1762,27 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@3.7.2:
+    resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      react: '>=16.8'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  zustand@4.3.9:
+    resolution: {integrity: sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      immer: '>=9.0'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -1433,6 +1878,10 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/runtime@7.26.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -1455,6 +1904,10 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@egjs/hammerjs@2.0.17':
+    dependencies:
+      '@types/hammerjs': 2.0.46
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1594,6 +2047,57 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@mediapipe/tasks-vision@0.10.8': {}
+
+  '@react-spring/animated@9.6.1(react@18.3.1)':
+    dependencies:
+      '@react-spring/shared': 9.6.1(react@18.3.1)
+      '@react-spring/types': 9.6.1
+      react: 18.3.1
+
+  '@react-spring/core@9.6.1(react@18.3.1)':
+    dependencies:
+      '@react-spring/animated': 9.6.1(react@18.3.1)
+      '@react-spring/rafz': 9.6.1
+      '@react-spring/shared': 9.6.1(react@18.3.1)
+      '@react-spring/types': 9.6.1
+      react: 18.3.1
+
+  '@react-spring/rafz@9.6.1': {}
+
+  '@react-spring/shared@9.6.1(react@18.3.1)':
+    dependencies:
+      '@react-spring/rafz': 9.6.1
+      '@react-spring/types': 9.6.1
+      react: 18.3.1
+
+  '@react-spring/three@9.6.1(@react-three/fiber@8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0))(react@18.3.1)(three@0.154.0)':
+    dependencies:
+      '@react-spring/animated': 9.6.1(react@18.3.1)
+      '@react-spring/core': 9.6.1(react@18.3.1)
+      '@react-spring/shared': 9.6.1(react@18.3.1)
+      '@react-spring/types': 9.6.1
+      '@react-three/fiber': 8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0)
+      react: 18.3.1
+      three: 0.154.0
+
+  '@react-spring/types@9.6.1': {}
+
+  '@react-three/fiber@8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@types/react-reconciler': 0.26.7
+      its-fine: 1.2.5(react@18.3.1)
+      react: 18.3.1
+      react-reconciler: 0.27.0(react@18.3.1)
+      react-use-measure: 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      scheduler: 0.21.0
+      suspend-react: 0.1.3(react@18.3.1)
+      three: 0.154.0
+      zustand: 3.7.2(react@18.3.1)
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   '@rollup/rollup-android-arm-eabi@4.27.3':
     optional: true
 
@@ -1648,6 +2152,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.27.3':
     optional: true
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.26.2
@@ -1669,9 +2175,15 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.0
 
+  '@types/draco3d@1.4.10': {}
+
   '@types/estree@1.0.6': {}
 
+  '@types/hammerjs@2.0.46': {}
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/offscreencanvas@2019.7.3': {}
 
   '@types/prop-types@15.7.13': {}
 
@@ -1679,10 +2191,38 @@ snapshots:
     dependencies:
       '@types/react': 18.3.12
 
+  '@types/react-reconciler@0.26.7':
+    dependencies:
+      '@types/react': 18.3.12
+
+  '@types/react-reconciler@0.28.8':
+    dependencies:
+      '@types/react': 18.3.12
+
   '@types/react@18.3.12':
     dependencies:
       '@types/prop-types': 15.7.13
       csstype: 3.1.3
+
+  '@types/stats.js@0.17.3': {}
+
+  '@types/three@0.170.0':
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.3
+      '@types/webxr': 0.5.20
+      '@webgpu/types': 0.1.51
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
+
+  '@types/webxr@0.5.20': {}
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@18.3.1)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 18.3.1
 
   '@vitejs/plugin-react@4.3.3(vite@5.4.11)':
     dependencies:
@@ -1694,6 +2234,10 @@ snapshots:
       vite: 5.4.11
     transitivePeerDependencies:
       - supports-color
+
+  '@webgpu/types@0.1.51': {}
+
+  '@yomguithereal/helpers@1.1.1': {}
 
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
@@ -1776,6 +2320,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -1798,6 +2346,10 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camera-controls@2.9.0(three@0.154.0):
+    dependencies:
+      three: 0.154.0
+
   caniuse-lite@1.0.30001683: {}
 
   chalk@4.1.2:
@@ -1805,15 +2357,23 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  classnames@2.5.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
 
+  component-emitter@1.3.1: {}
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1822,6 +2382,14 @@ snapshots:
       which: 2.0.2
 
   csstype@3.1.3: {}
+
+  ctrl-keys@1.0.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-binarytree@1.0.2: {}
 
   d3-color@1.4.1: {}
 
@@ -1833,6 +2401,14 @@ snapshots:
       d3-selection: 1.4.2
 
   d3-ease@1.0.7: {}
+
+  d3-force-3d@3.0.5:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 1.0.6
+      d3-octree: 1.0.2
+      d3-quadtree: 3.0.1
+      d3-timer: 1.0.10
 
   d3-format@1.4.5: {}
 
@@ -1848,13 +2424,35 @@ snapshots:
       d3-zoom: 1.8.3
       viz.js: 1.8.2
 
+  d3-hierarchy@3.1.2: {}
+
   d3-interpolate@1.4.0:
     dependencies:
       d3-color: 1.4.1
 
+  d3-octree@1.0.2: {}
+
   d3-path@1.0.9: {}
 
+  d3-quadtree@3.0.1: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 1.4.5
+      d3-interpolate: 1.4.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
   d3-selection@1.4.2: {}
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   d3-timer@1.0.10: {}
 
@@ -1893,6 +2491,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  debounce@1.2.1: {}
+
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
@@ -1913,11 +2513,19 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  detect-gpu@5.0.58:
+    dependencies:
+      webgl-constants: 1.1.1
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
 
+  draco3d@1.5.7: {}
+
   electron-to-chromium@1.5.64: {}
+
+  ellipsize@0.5.1: {}
 
   es-abstract@1.23.5:
     dependencies:
@@ -2138,11 +2746,17 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events@3.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fflate@0.6.10: {}
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -2211,9 +2825,94 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.0.1
 
+  glodrei@0.0.1(@react-three/fiber@8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0))(@types/three@0.170.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@mediapipe/tasks-vision': 0.10.8
+      '@react-spring/three': 9.6.1(@react-three/fiber@8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0))(react@18.3.1)(three@0.154.0)
+      '@react-three/fiber': 8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0)
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      camera-controls: 2.9.0(three@0.154.0)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.58
+      glsl-noise: 0.0.0
+      maath: 0.10.8(@types/three@0.170.0)(three@0.154.0)
+      meshline: 3.3.1(three@0.154.0)
+      react: 18.3.1
+      react-composer: 5.0.3(react@18.3.1)
+      react-merge-refs: 1.1.0
+      stats-gl: 2.4.2(@types/three@0.170.0)(three@0.154.0)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@18.3.1)
+      three: 0.154.0
+      three-mesh-bvh: 0.7.6(three@0.154.0)
+      three-stdlib: 2.34.0(three@0.154.0)
+      troika-three-text: 0.47.2(three@0.154.0)
+      tunnel-rat: 0.1.2(react@18.3.1)
+      utility-types: 3.11.0
+      uuid: 9.0.1
+      zustand: 3.7.2(react@18.3.1)
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/three'
+      - immer
+
+  glsl-noise@0.0.0: {}
+
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.4
+
+  graphology-indices@0.17.0(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+      mnemonist: 0.39.8
+
+  graphology-layout-forceatlas2@0.10.1(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+
+  graphology-layout-noverlap@0.4.2(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+
+  graphology-layout@0.6.1(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+      pandemonium: 2.4.1
+
+  graphology-metrics@2.3.1(graphology-types@0.24.8):
+    dependencies:
+      graphology-indices: 0.17.0(graphology-types@0.24.8)
+      graphology-shortest-path: 2.1.0(graphology-types@0.24.8)
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+      mnemonist: 0.39.8
+
+  graphology-shortest-path@2.1.0(graphology-types@0.24.8):
+    dependencies:
+      '@yomguithereal/helpers': 1.1.1
+      graphology-indices: 0.17.0(graphology-types@0.24.8)
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+      mnemonist: 0.39.8
+
+  graphology-types@0.24.8: {}
+
+  graphology-utils@2.5.2(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+
+  graphology@0.25.4(graphology-types@0.24.8):
+    dependencies:
+      events: 3.3.0
+      graphology-types: 0.24.8
+      obliterator: 2.0.4
 
   graphviz-react@1.2.5(react@18.3.1):
     dependencies:
@@ -2240,6 +2939,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hold-event@0.2.0: {}
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.0:
@@ -2254,6 +2955,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.4:
     dependencies:
@@ -2355,6 +3058,11 @@ snapshots:
       reflect.getprototypeof: 1.0.6
       set-function-name: 2.0.2
 
+  its-fine@1.2.5(react@18.3.1):
+    dependencies:
+      '@types/react-reconciler': 0.28.8
+      react: 18.3.1
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -2378,6 +3086,8 @@ snapshots:
       object.assign: 4.1.5
       object.values: 1.2.0
 
+  keycharm@0.4.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -2393,6 +3103,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -2401,9 +3113,24 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  maath@0.10.8(@types/three@0.170.0)(three@0.154.0):
+    dependencies:
+      '@types/three': 0.170.0
+      three: 0.154.0
+
+  meshline@3.3.1(three@0.154.0):
+    dependencies:
+      three: 0.154.0
+
+  meshoptimizer@0.18.1: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
+
+  mnemonist@0.39.8:
+    dependencies:
+      obliterator: 2.0.4
 
   ms@2.1.3: {}
 
@@ -2445,6 +3172,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
 
+  obliterator@2.0.4: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2461,6 +3190,10 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  pandemonium@2.4.1:
+    dependencies:
+      mnemonist: 0.39.8
 
   parent-module@1.0.1:
     dependencies:
@@ -2482,6 +3215,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@1.0.2: {}
+
   prelude-ls@1.2.1: {}
 
   prop-types@15.8.1:
@@ -2498,19 +3233,93 @@ snapshots:
       filter-obj: 5.1.0
       split-on-first: 3.0.0
 
+  react-composer@5.0.3(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.3.1
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-graph-vis@1.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(react@18.3.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
+    dependencies:
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.3.1
+      uuid: 2.0.3
+      vis-data: 7.1.9(uuid@2.0.3)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      vis-network: 9.1.9(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@2.0.3)(vis-data@7.1.9(uuid@2.0.3)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+    transitivePeerDependencies:
+      - '@egjs/hammerjs'
+      - component-emitter
+      - keycharm
+      - vis-util
+
   react-is@16.13.1: {}
 
+  react-merge-refs@1.1.0: {}
+
+  react-reconciler@0.27.0(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.21.0
+
   react-refresh@0.14.2: {}
+
+  react-use-measure@2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      debounce: 1.2.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  reagraph@4.21.0(@types/three@0.170.0)(graphology-types@0.24.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@react-spring/three': 9.6.1(@react-three/fiber@8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0))(react@18.3.1)(three@0.154.0)
+      '@react-three/fiber': 8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0)
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      camera-controls: 2.9.0(three@0.154.0)
+      classnames: 2.5.1
+      d3-array: 3.2.4
+      d3-force-3d: 3.0.5
+      d3-hierarchy: 3.1.2
+      d3-scale: 4.0.2
+      ellipsize: 0.5.1
+      glodrei: 0.0.1(@react-three/fiber@8.13.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0))(@types/three@0.170.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.154.0)
+      graphology: 0.25.4(graphology-types@0.24.8)
+      graphology-layout: 0.6.1(graphology-types@0.24.8)
+      graphology-layout-forceatlas2: 0.10.1(graphology-types@0.24.8)
+      graphology-layout-noverlap: 0.4.2(graphology-types@0.24.8)
+      graphology-metrics: 2.3.1(graphology-types@0.24.8)
+      graphology-shortest-path: 2.1.0(graphology-types@0.24.8)
+      hold-event: 0.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reakeys: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      three: 0.154.0
+      three-stdlib: 2.34.0(three@0.154.0)
+      zustand: 4.3.9(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/three'
+      - expo
+      - expo-asset
+      - expo-gl
+      - graphology-types
+      - immer
+      - react-native
+
+  reakeys@2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      ctrl-keys: 1.0.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   reflect.getprototypeof@1.0.6:
     dependencies:
@@ -2522,12 +3331,16 @@ snapshots:
       globalthis: 1.0.4
       which-builtin-type: 1.1.4
 
+  regenerator-runtime@0.14.1: {}
+
   regexp.prototype.flags@1.5.3:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -2574,6 +3387,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.1.4
 
+  scheduler@0.21.0:
+    dependencies:
+      loose-envify: 1.4.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -2612,6 +3429,13 @@ snapshots:
   source-map-js@1.2.1: {}
 
   split-on-first@3.0.0: {}
+
+  stats-gl@2.4.2(@types/three@0.170.0)(three@0.154.0):
+    dependencies:
+      '@types/three': 0.170.0
+      three: 0.154.0
+
+  stats.js@0.17.0: {}
 
   string.prototype.matchall@4.0.11:
     dependencies:
@@ -2659,6 +3483,47 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  suspend-react@0.1.3(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  three-mesh-bvh@0.7.6(three@0.154.0):
+    dependencies:
+      three: 0.154.0
+
+  three-stdlib@2.34.0(three@0.154.0):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.20
+      draco3d: 1.5.7
+      fflate: 0.6.10
+      potpack: 1.0.2
+      three: 0.154.0
+
+  three@0.154.0: {}
+
+  troika-three-text@0.47.2(three@0.154.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.154.0
+      troika-three-utils: 0.47.2(three@0.154.0)
+      troika-worker-utils: 0.47.2
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.47.2(three@0.154.0):
+    dependencies:
+      three: 0.154.0
+
+  troika-worker-utils@0.47.2: {}
+
+  tunnel-rat@0.1.2(react@18.3.1):
+    dependencies:
+      zustand: 4.3.9(react@18.3.1)
+    transitivePeerDependencies:
+      - immer
+      - react
 
   type-check@0.4.0:
     dependencies:
@@ -2714,6 +3579,35 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  utility-types@3.11.0: {}
+
+  uuid@2.0.3: {}
+
+  uuid@9.0.1: {}
+
+  vis-data@7.1.9(uuid@2.0.3)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
+    dependencies:
+      uuid: 2.0.3
+      vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
+
+  vis-network@9.1.9(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@2.0.3)(vis-data@7.1.9(uuid@2.0.3)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      component-emitter: 1.3.1
+      keycharm: 0.4.0
+      uuid: 2.0.3
+      vis-data: 7.1.9(uuid@2.0.3)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
+
+  vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      component-emitter: 1.3.1
+
   vite@5.4.11:
     dependencies:
       esbuild: 0.21.5
@@ -2723,6 +3617,10 @@ snapshots:
       fsevents: 2.3.3
 
   viz.js@1.8.2: {}
+
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
 
   which-boxed-primitive@1.0.2:
     dependencies:
@@ -2771,3 +3669,13 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@3.7.2(react@18.3.1):
+    optionalDependencies:
+      react: 18.3.1
+
+  zustand@4.3.9(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.2.0(react@18.3.1)
+    optionalDependencies:
+      react: 18.3.1

--- a/pkg/topology/embed/frontend/pnpm-lock.yaml
+++ b/pkg/topology/embed/frontend/pnpm-lock.yaml
@@ -1,0 +1,2773 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      graphviz-react:
+        specifier: ^1.2.5
+        version: 1.2.5(react@18.3.1)
+      query-string:
+        specifier: ^9.1.1
+        version: 9.1.1
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.13.0
+        version: 9.15.0
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.1
+      '@vitejs/plugin-react':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@5.4.11)
+      eslint:
+        specifier: ^9.13.0
+        version: 9.15.0
+      eslint-plugin-react:
+        specifier: ^7.37.2
+        version: 7.37.2(eslint@9.15.0)
+      eslint-plugin-react-hooks:
+        specifier: ^5.0.0
+        version: 5.0.0(eslint@9.15.0)
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.14
+        version: 0.4.14(eslint@9.15.0)
+      globals:
+        specifier: ^15.11.0
+        version: 15.12.0
+      vite:
+        specifier: ^5.4.10
+        version: 5.4.11
+
+packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.26.2':
+    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.26.0':
+    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.26.2':
+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.25.9':
+    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.25.9':
+    resolution: {integrity: sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.26.0':
+    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.26.2':
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9':
+    resolution: {integrity: sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9':
+    resolution: {integrity: sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.25.9':
+    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.25.9':
+    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.0':
+    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.4.1':
+    resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.19.0':
+    resolution: {integrity: sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.9.0':
+    resolution: {integrity: sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.2.0':
+    resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.15.0':
+    resolution: {integrity: sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.4':
+    resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.2.3':
+    resolution: {integrity: sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.1':
+    resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
+    engines: {node: '>=18.18'}
+
+  '@jridgewell/gen-mapping@0.3.5':
+    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@rollup/rollup-android-arm-eabi@4.27.3':
+    resolution: {integrity: sha512-EzxVSkIvCFxUd4Mgm4xR9YXrcp976qVaHnqom/Tgm+vU79k4vV4eYTjmRvGfeoW8m9LVcsAy/lGjcgVegKEhLQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.27.3':
+    resolution: {integrity: sha512-LJc5pDf1wjlt9o/Giaw9Ofl+k/vLUaYsE2zeQGH85giX2F+wn/Cg8b3c5CDP3qmVmeO5NzwVUzQQxwZvC2eQKw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.27.3':
+    resolution: {integrity: sha512-OuRysZ1Mt7wpWJ+aYKblVbJWtVn3Cy52h8nLuNSzTqSesYw1EuN6wKp5NW/4eSre3mp12gqFRXOKTcN3AI3LqA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.27.3':
+    resolution: {integrity: sha512-xW//zjJMlJs2sOrCmXdB4d0uiilZsOdlGQIC/jjmMWT47lkLLoB1nsNhPUcnoqyi5YR6I4h+FjBpILxbEy8JRg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.27.3':
+    resolution: {integrity: sha512-58E0tIcwZ+12nK1WiLzHOD8I0d0kdrY/+o7yFVPRHuVGY3twBwzwDdTIBGRxLmyjciMYl1B/U515GJy+yn46qw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.27.3':
+    resolution: {integrity: sha512-78fohrpcVwTLxg1ZzBMlwEimoAJmY6B+5TsyAZ3Vok7YabRBUvjYTsRXPTjGEvv/mfgVBepbW28OlMEz4w8wGA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.27.3':
+    resolution: {integrity: sha512-h2Ay79YFXyQi+QZKo3ISZDyKaVD7uUvukEHTOft7kh00WF9mxAaxZsNs3o/eukbeKuH35jBvQqrT61fzKfAB/Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.27.3':
+    resolution: {integrity: sha512-Sv2GWmrJfRY57urktVLQ0VKZjNZGogVtASAgosDZ1aUB+ykPxSi3X1nWORL5Jk0sTIIwQiPH7iE3BMi9zGWfkg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.27.3':
+    resolution: {integrity: sha512-FPoJBLsPW2bDNWjSrwNuTPUt30VnfM8GPGRoLCYKZpPx0xiIEdFip3dH6CqgoT0RnoGXptaNziM0WlKgBc+OWQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.27.3':
+    resolution: {integrity: sha512-TKxiOvBorYq4sUpA0JT+Fkh+l+G9DScnG5Dqx7wiiqVMiRSkzTclP35pE6eQQYjP4Gc8yEkJGea6rz4qyWhp3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.27.3':
+    resolution: {integrity: sha512-v2M/mPvVUKVOKITa0oCFksnQQ/TqGrT+yD0184/cWHIu0LoIuYHwox0Pm3ccXEz8cEQDLk6FPKd1CCm+PlsISw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.27.3':
+    resolution: {integrity: sha512-LdrI4Yocb1a/tFVkzmOE5WyYRgEBOyEhWYJe4gsDWDiwnjYKjNs7PS6SGlTDB7maOHF4kxevsuNBl2iOcj3b4A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.27.3':
+    resolution: {integrity: sha512-d4wVu6SXij/jyiwPvI6C4KxdGzuZOvJ6y9VfrcleHTwo68fl8vZC5ZYHsCVPUi4tndCfMlFniWgwonQ5CUpQcA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.27.3':
+    resolution: {integrity: sha512-/6bn6pp1fsCGEY5n3yajmzZQAh+mW4QPItbiWxs69zskBzJuheb3tNynEjL+mKOsUSFK11X4LYF2BwwXnzWleA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.27.3':
+    resolution: {integrity: sha512-nBXOfJds8OzUT1qUreT/en3eyOXd2EH5b0wr2bVB5999qHdGKkzGzIyKYaKj02lXk6wpN71ltLIaQpu58YFBoQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-win32-arm64-msvc@4.27.3':
+    resolution: {integrity: sha512-ogfbEVQgIZOz5WPWXF2HVb6En+kWzScuxJo/WdQTqEgeyGkaa2ui5sQav9Zkr7bnNCLK48uxmmK0TySm22eiuw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.27.3':
+    resolution: {integrity: sha512-ecE36ZBMLINqiTtSNQ1vzWc5pXLQHlf/oqGp/bSbi7iedcjcNb6QbCBNG73Euyy2C+l/fn8qKWEwxr+0SSfs3w==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.27.3':
+    resolution: {integrity: sha512-vliZLrDmYKyaUoMzEbMTg2JkerfBjn03KmAw9CykO0Zzkzoyd7o3iZNam/TpyWNjNT+Cz2iO3P9Smv2wgrR+Eg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.6.8':
+    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.20.6':
+    resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
+
+  '@types/estree@1.0.6':
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/prop-types@15.7.13':
+    resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
+
+  '@types/react-dom@18.3.1':
+    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
+
+  '@types/react@18.3.12':
+    resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
+
+  '@vitejs/plugin-react@4.3.3':
+    resolution: {integrity: sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-buffer-byte-length@1.0.1:
+    resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.8:
+    resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlast@1.2.5:
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.2:
+    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.2:
+    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.3:
+    resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
+    engines: {node: '>= 0.4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+
+  browserslist@4.24.2:
+    resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  call-bind@1.0.7:
+    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001683:
+    resolution: {integrity: sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  d3-color@1.4.1:
+    resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
+
+  d3-dispatch@1.0.6:
+    resolution: {integrity: sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==}
+
+  d3-drag@1.2.5:
+    resolution: {integrity: sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==}
+
+  d3-ease@1.0.7:
+    resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
+
+  d3-format@1.4.5:
+    resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
+
+  d3-graphviz@2.6.1:
+    resolution: {integrity: sha512-878AFSagQyr5tTOrM7YiVYeUC2/NoFcOB3/oew+LAML0xekyJSw9j3WOCUMBsc95KYe9XBYZ+SKKuObVya1tJQ==}
+
+  d3-interpolate@1.4.0:
+    resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-selection@1.4.2:
+    resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
+
+  d3-timer@1.0.10:
+    resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
+
+  d3-transition@1.3.2:
+    resolution: {integrity: sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==}
+
+  d3-zoom@1.8.3:
+    resolution: {integrity: sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==}
+
+  data-view-buffer@1.0.1:
+    resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.1:
+    resolution: {integrity: sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.0:
+    resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
+    engines: {node: '>= 0.4'}
+
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
+
+  electron-to-chromium@1.5.64:
+    resolution: {integrity: sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==}
+
+  es-abstract@1.23.5:
+    resolution: {integrity: sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-iterator-helpers@1.2.0:
+    resolution: {integrity: sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.0.0:
+    resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.0.3:
+    resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.0.2:
+    resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
+
+  es-to-primitive@1.2.1:
+    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-react-hooks@5.0.0:
+    resolution: {integrity: sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.14:
+    resolution: {integrity: sha512-aXvzCTK7ZBv1e7fahFuR3Z/fyQQSIQ711yPgYRj+Oj64tyTgO4iQIDmYXDBqvSWQ/FA4OSCsXOStlF+noU0/NA==}
+    peerDependencies:
+      eslint: '>=7'
+
+  eslint-plugin-react@7.37.2:
+    resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-scope@8.2.0:
+    resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.15.0:
+    resolution: {integrity: sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.3.0:
+    resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.2:
+    resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
+
+  for-each@0.3.3:
+    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.1.6:
+    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.0.2:
+    resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
+    engines: {node: '>= 0.4'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@15.12.0:
+    resolution: {integrity: sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==}
+    engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+
+  graphviz-react@1.2.5:
+    resolution: {integrity: sha512-IRFDzEt09hRzfqrrvAW1PAPBqG4t8hykArcoxq7UhEqO5RUKCBN6126D6rjiL2QAwAznbUSg0Fba2RnSH2V4sA==}
+    engines: {npm: '>= 8.3'}
+    peerDependencies:
+      react: '>= 16.13.1'
+
+  has-bigints@1.0.2:
+    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.0.3:
+    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  internal-slot@1.0.7:
+    resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.4:
+    resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.0.0:
+    resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.0.4:
+    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
+
+  is-boolean-object@1.1.2:
+    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.15.1:
+    resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.1:
+    resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.0.5:
+    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-finalizationregistry@1.0.2:
+    resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
+
+  is-generator-function@1.0.10:
+    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
+    engines: {node: '>= 0.4'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.0.7:
+    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
+    engines: {node: '>= 0.4'}
+
+  is-regex@1.1.4:
+    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.0.7:
+    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.0.4:
+    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.13:
+    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.0.2:
+    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
+
+  is-weakset@2.0.3:
+    resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  iterator.prototype@1.1.3:
+    resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
+    engines: {node: '>= 0.4'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  jsesc@3.0.2:
+    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-releases@2.0.18:
+    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.3:
+    resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.5:
+    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
+    engines: {node: '>= 0.4'}
+
+  object.entries@1.1.8:
+    resolution: {integrity: sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.0:
+    resolution: {integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==}
+    engines: {node: '>= 0.4'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  possible-typed-array-names@1.0.0:
+    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
+    engines: {node: '>= 0.4'}
+
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  query-string@9.1.1:
+    resolution: {integrity: sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==}
+    engines: {node: '>=18'}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-refresh@0.14.2:
+    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  reflect.getprototypeof@1.0.6:
+    resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.3:
+    resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
+    engines: {node: '>= 0.4'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve@2.0.0-next.5:
+    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
+    hasBin: true
+
+  rollup@4.27.3:
+    resolution: {integrity: sha512-SLsCOnlmGt9VoZ9Ek8yBK8tAdmPHeppkw+Xa7yDlCEhDTvwYei03JlWo1fdc7YTfLZ4tD8riJCUyAgTbszk1fQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  safe-array-concat@1.1.2:
+    resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
+    engines: {node: '>=0.4'}
+
+  safe-regex-test@1.0.3:
+    resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
+    engines: {node: '>= 0.4'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel@1.0.6:
+    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+    engines: {node: '>= 0.4'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
+
+  string.prototype.matchall@4.0.11:
+    resolution: {integrity: sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.repeat@1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+
+  string.prototype.trim@1.2.9:
+    resolution: {integrity: sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.8:
+    resolution: {integrity: sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typed-array-buffer@1.0.2:
+    resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.1:
+    resolution: {integrity: sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.3:
+    resolution: {integrity: sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.6:
+    resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
+    engines: {node: '>= 0.4'}
+
+  unbox-primitive@1.0.2:
+    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  update-browserslist-db@1.1.1:
+    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite@5.4.11:
+    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  viz.js@1.8.2:
+    resolution: {integrity: sha512-W+1+N/hdzLpQZEcvz79n2IgUE9pfx6JLdHh3Kh8RGvLL8P1LdJVQmi2OsDcLdY4QVID4OUy+FPelyerX0nJxIQ==}
+    deprecated: 2.x is no longer supported, 3.x published as @viz-js/viz
+
+  which-boxed-primitive@1.0.2:
+    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
+
+  which-builtin-type@1.1.4:
+    resolution: {integrity: sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.15:
+    resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
+    engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.26.2': {}
+
+  '@babel/core@7.26.0':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
+      '@babel/helpers': 7.26.0
+      '@babel/parser': 7.26.2
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+      convert-source-map: 2.0.0
+      debug: 4.3.7
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.26.2':
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
+  '@babel/helper-compilation-targets@7.25.9':
+    dependencies:
+      '@babel/compat-data': 7.26.2
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.25.9': {}
+
+  '@babel/helper-string-parser@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
+
+  '@babel/helpers@7.26.0':
+    dependencies:
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
+
+  '@babel/parser@7.26.2':
+    dependencies:
+      '@babel/types': 7.26.0
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/template@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+
+  '@babel/traverse@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
+      debug: 4.3.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.26.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.15.0)':
+    dependencies:
+      eslint: 9.15.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.19.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.4
+      debug: 4.3.7
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/core@0.9.0': {}
+
+  '@eslint/eslintrc@3.2.0':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.7
+      espree: 10.3.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.15.0': {}
+
+  '@eslint/object-schema@2.1.4': {}
+
+  '@eslint/plugin-kit@0.2.3':
+    dependencies:
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.6':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.3.1': {}
+
+  '@humanwhocodes/retry@0.4.1': {}
+
+  '@jridgewell/gen-mapping@0.3.5':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/set-array@1.2.1': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@rollup/rollup-android-arm-eabi@4.27.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.27.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.27.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.27.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.27.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.27.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.27.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.27.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.27.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.27.3':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+      '@types/babel__generator': 7.6.8
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.6
+
+  '@types/babel__generator@7.6.8':
+    dependencies:
+      '@babel/types': 7.26.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+
+  '@types/babel__traverse@7.20.6':
+    dependencies:
+      '@babel/types': 7.26.0
+
+  '@types/estree@1.0.6': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/prop-types@15.7.13': {}
+
+  '@types/react-dom@18.3.1':
+    dependencies:
+      '@types/react': 18.3.12
+
+  '@types/react@18.3.12':
+    dependencies:
+      '@types/prop-types': 15.7.13
+      csstype: 3.1.3
+
+  '@vitejs/plugin-react@4.3.3(vite@5.4.11)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 5.4.11
+    transitivePeerDependencies:
+      - supports-color
+
+  acorn-jsx@5.3.2(acorn@8.14.0):
+    dependencies:
+      acorn: 8.14.0
+
+  acorn@8.14.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-buffer-byte-length@1.0.1:
+    dependencies:
+      call-bind: 1.0.7
+      is-array-buffer: 3.0.4
+
+  array-includes@3.1.8:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-object-atoms: 1.0.0
+      get-intrinsic: 1.2.4
+      is-string: 1.0.7
+
+  array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      es-shim-unscopables: 1.0.2
+
+  array.prototype.flat@1.3.2:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-shim-unscopables: 1.0.2
+
+  array.prototype.flatmap@1.3.2:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-shim-unscopables: 1.0.2
+
+  array.prototype.tosorted@1.1.4:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-errors: 1.3.0
+      es-shim-unscopables: 1.0.2
+
+  arraybuffer.prototype.slice@1.0.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.1
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
+      is-array-buffer: 3.0.4
+      is-shared-array-buffer: 1.0.3
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.0.0
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.11:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  browserslist@4.24.2:
+    dependencies:
+      caniuse-lite: 1.0.30001683
+      electron-to-chromium: 1.5.64
+      node-releases: 2.0.18
+      update-browserslist-db: 1.1.1(browserslist@4.24.2)
+
+  call-bind@1.0.7:
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      set-function-length: 1.2.2
+
+  callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001683: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  csstype@3.1.3: {}
+
+  d3-color@1.4.1: {}
+
+  d3-dispatch@1.0.6: {}
+
+  d3-drag@1.2.5:
+    dependencies:
+      d3-dispatch: 1.0.6
+      d3-selection: 1.4.2
+
+  d3-ease@1.0.7: {}
+
+  d3-format@1.4.5: {}
+
+  d3-graphviz@2.6.1:
+    dependencies:
+      d3-dispatch: 1.0.6
+      d3-format: 1.4.5
+      d3-interpolate: 1.4.0
+      d3-path: 1.0.9
+      d3-selection: 1.4.2
+      d3-timer: 1.0.10
+      d3-transition: 1.3.2
+      d3-zoom: 1.8.3
+      viz.js: 1.8.2
+
+  d3-interpolate@1.4.0:
+    dependencies:
+      d3-color: 1.4.1
+
+  d3-path@1.0.9: {}
+
+  d3-selection@1.4.2: {}
+
+  d3-timer@1.0.10: {}
+
+  d3-transition@1.3.2:
+    dependencies:
+      d3-color: 1.4.1
+      d3-dispatch: 1.0.6
+      d3-ease: 1.0.7
+      d3-interpolate: 1.4.0
+      d3-selection: 1.4.2
+      d3-timer: 1.0.10
+
+  d3-zoom@1.8.3:
+    dependencies:
+      d3-dispatch: 1.0.6
+      d3-drag: 1.2.5
+      d3-interpolate: 1.4.0
+      d3-selection: 1.4.2
+      d3-transition: 1.3.2
+
+  data-view-buffer@1.0.1:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      is-data-view: 1.0.1
+
+  data-view-byte-length@1.0.1:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      is-data-view: 1.0.1
+
+  data-view-byte-offset@1.0.0:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      is-data-view: 1.0.1
+
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
+  decode-uri-component@0.4.1: {}
+
+  deep-is@0.1.4: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      gopd: 1.0.1
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
+  doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
+
+  electron-to-chromium@1.5.64: {}
+
+  es-abstract@1.23.5:
+    dependencies:
+      array-buffer-byte-length: 1.0.1
+      arraybuffer.prototype.slice: 1.0.3
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.7
+      data-view-buffer: 1.0.1
+      data-view-byte-length: 1.0.1
+      data-view-byte-offset: 1.0.0
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      es-set-tostringtag: 2.0.3
+      es-to-primitive: 1.2.1
+      function.prototype.name: 1.1.6
+      get-intrinsic: 1.2.4
+      get-symbol-description: 1.0.2
+      globalthis: 1.0.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      hasown: 2.0.2
+      internal-slot: 1.0.7
+      is-array-buffer: 3.0.4
+      is-callable: 1.2.7
+      is-data-view: 1.0.1
+      is-negative-zero: 2.0.3
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.3
+      is-string: 1.0.7
+      is-typed-array: 1.1.13
+      is-weakref: 1.0.2
+      object-inspect: 1.13.3
+      object-keys: 1.1.1
+      object.assign: 4.1.5
+      regexp.prototype.flags: 1.5.3
+      safe-array-concat: 1.1.2
+      safe-regex-test: 1.0.3
+      string.prototype.trim: 1.2.9
+      string.prototype.trimend: 1.0.8
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.2
+      typed-array-byte-length: 1.0.1
+      typed-array-byte-offset: 1.0.3
+      typed-array-length: 1.0.6
+      unbox-primitive: 1.0.2
+      which-typed-array: 1.1.15
+
+  es-define-property@1.0.0:
+    dependencies:
+      get-intrinsic: 1.2.4
+
+  es-errors@1.3.0: {}
+
+  es-iterator-helpers@1.2.0:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.0.3
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      globalthis: 1.0.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      internal-slot: 1.0.7
+      iterator.prototype: 1.1.3
+      safe-array-concat: 1.1.2
+
+  es-object-atoms@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.0.3:
+    dependencies:
+      get-intrinsic: 1.2.4
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-shim-unscopables@1.0.2:
+    dependencies:
+      hasown: 2.0.2
+
+  es-to-primitive@1.2.1:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.0.5
+      is-symbol: 1.0.4
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-react-hooks@5.0.0(eslint@9.15.0):
+    dependencies:
+      eslint: 9.15.0
+
+  eslint-plugin-react-refresh@0.4.14(eslint@9.15.0):
+    dependencies:
+      eslint: 9.15.0
+
+  eslint-plugin-react@7.37.2(eslint@9.15.0):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.2
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.0
+      eslint: 9.15.0
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.8
+      object.fromentries: 2.0.8
+      object.values: 1.2.0
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.11
+      string.prototype.repeat: 1.0.0
+
+  eslint-scope@8.2.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.0: {}
+
+  eslint@9.15.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.15.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.19.0
+      '@eslint/core': 0.9.0
+      '@eslint/eslintrc': 3.2.0
+      '@eslint/js': 9.15.0
+      '@eslint/plugin-kit': 0.2.3
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.1
+      '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.3.7
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.2.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.3.0:
+    dependencies:
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
+      eslint-visitor-keys: 4.2.0
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  filter-obj@5.1.0: {}
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.2
+      keyv: 4.5.4
+
+  flatted@3.3.2: {}
+
+  for-each@0.3.3:
+    dependencies:
+      is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.6:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      functions-have-names: 1.2.3
+
+  functions-have-names@1.2.3: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.2.4:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      hasown: 2.0.2
+
+  get-symbol-description@1.0.2:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@11.12.0: {}
+
+  globals@14.0.0: {}
+
+  globals@15.12.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.0.1
+
+  gopd@1.0.1:
+    dependencies:
+      get-intrinsic: 1.2.4
+
+  graphviz-react@1.2.5(react@18.3.1):
+    dependencies:
+      d3-graphviz: 2.6.1
+      react: 18.3.1
+
+  has-bigints@1.0.2: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.0
+
+  has-proto@1.0.3: {}
+
+  has-symbols@1.0.3: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.0.3
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.0:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  internal-slot@1.0.7:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.0.6
+
+  is-array-buffer@3.0.4:
+    dependencies:
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
+
+  is-async-function@2.0.0:
+    dependencies:
+      has-tostringtag: 1.0.2
+
+  is-bigint@1.0.4:
+    dependencies:
+      has-bigints: 1.0.2
+
+  is-boolean-object@1.1.2:
+    dependencies:
+      call-bind: 1.0.7
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.15.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-data-view@1.0.1:
+    dependencies:
+      is-typed-array: 1.1.13
+
+  is-date-object@1.0.5:
+    dependencies:
+      has-tostringtag: 1.0.2
+
+  is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.0.2:
+    dependencies:
+      call-bind: 1.0.7
+
+  is-generator-function@1.0.10:
+    dependencies:
+      has-tostringtag: 1.0.2
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.0.7:
+    dependencies:
+      has-tostringtag: 1.0.2
+
+  is-regex@1.1.4:
+    dependencies:
+      call-bind: 1.0.7
+      has-tostringtag: 1.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.3:
+    dependencies:
+      call-bind: 1.0.7
+
+  is-string@1.0.7:
+    dependencies:
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.0.4:
+    dependencies:
+      has-symbols: 1.0.3
+
+  is-typed-array@1.1.13:
+    dependencies:
+      which-typed-array: 1.1.15
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.0.2:
+    dependencies:
+      call-bind: 1.0.7
+
+  is-weakset@2.0.3:
+    dependencies:
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  iterator.prototype@1.1.3:
+    dependencies:
+      define-properties: 1.2.1
+      get-intrinsic: 1.2.4
+      has-symbols: 1.0.3
+      reflect.getprototypeof: 1.0.6
+      set-function-name: 2.0.2
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.0.2: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
+
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.flat: 1.3.2
+      object.assign: 4.1.5
+      object.values: 1.2.0
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.11
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.7: {}
+
+  natural-compare@1.4.0: {}
+
+  node-releases@2.0.18: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.3: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.5:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      has-symbols: 1.0.3
+      object-keys: 1.1.1
+
+  object.entries@1.1.8:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-object-atoms: 1.0.0
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-object-atoms: 1.0.0
+
+  object.values@1.2.0:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-object-atoms: 1.0.0
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  picocolors@1.1.1: {}
+
+  possible-typed-array-names@1.0.0: {}
+
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  punycode@2.3.1: {}
+
+  query-string@9.1.1:
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-is@16.13.1: {}
+
+  react-refresh@0.14.2: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  reflect.getprototypeof@1.0.6:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
+      globalthis: 1.0.4
+      which-builtin-type: 1.1.4
+
+  regexp.prototype.flags@1.5.3:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      set-function-name: 2.0.2
+
+  resolve-from@4.0.0: {}
+
+  resolve@2.0.0-next.5:
+    dependencies:
+      is-core-module: 2.15.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  rollup@4.27.3:
+    dependencies:
+      '@types/estree': 1.0.6
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.27.3
+      '@rollup/rollup-android-arm64': 4.27.3
+      '@rollup/rollup-darwin-arm64': 4.27.3
+      '@rollup/rollup-darwin-x64': 4.27.3
+      '@rollup/rollup-freebsd-arm64': 4.27.3
+      '@rollup/rollup-freebsd-x64': 4.27.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.27.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.27.3
+      '@rollup/rollup-linux-arm64-gnu': 4.27.3
+      '@rollup/rollup-linux-arm64-musl': 4.27.3
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.27.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.27.3
+      '@rollup/rollup-linux-s390x-gnu': 4.27.3
+      '@rollup/rollup-linux-x64-gnu': 4.27.3
+      '@rollup/rollup-linux-x64-musl': 4.27.3
+      '@rollup/rollup-win32-arm64-msvc': 4.27.3
+      '@rollup/rollup-win32-ia32-msvc': 4.27.3
+      '@rollup/rollup-win32-x64-msvc': 4.27.3
+      fsevents: 2.3.3
+
+  safe-array-concat@1.1.2:
+    dependencies:
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
+      has-symbols: 1.0.3
+      isarray: 2.0.5
+
+  safe-regex-test@1.0.3:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      is-regex: 1.1.4
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel@1.0.6:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
+      object-inspect: 1.13.3
+
+  source-map-js@1.2.1: {}
+
+  split-on-first@3.0.0: {}
+
+  string.prototype.matchall@4.0.11:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      get-intrinsic: 1.2.4
+      gopd: 1.0.1
+      has-symbols: 1.0.3
+      internal-slot: 1.0.7
+      regexp.prototype.flags: 1.5.3
+      set-function-name: 2.0.2
+      side-channel: 1.0.6
+
+  string.prototype.repeat@1.0.0:
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+
+  string.prototype.trim@1.2.9:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-object-atoms: 1.0.0
+
+  string.prototype.trimend@1.0.8:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-object-atoms: 1.0.0
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-object-atoms: 1.0.0
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typed-array-buffer@1.0.2:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      is-typed-array: 1.1.13
+
+  typed-array-byte-length@1.0.1:
+    dependencies:
+      call-bind: 1.0.7
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-proto: 1.0.3
+      is-typed-array: 1.1.13
+
+  typed-array-byte-offset@1.0.3:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.7
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-proto: 1.0.3
+      is-typed-array: 1.1.13
+      reflect.getprototypeof: 1.0.6
+
+  typed-array-length@1.0.6:
+    dependencies:
+      call-bind: 1.0.7
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-proto: 1.0.3
+      is-typed-array: 1.1.13
+      possible-typed-array-names: 1.0.0
+
+  unbox-primitive@1.0.2:
+    dependencies:
+      call-bind: 1.0.7
+      has-bigints: 1.0.2
+      has-symbols: 1.0.3
+      which-boxed-primitive: 1.0.2
+
+  update-browserslist-db@1.1.1(browserslist@4.24.2):
+    dependencies:
+      browserslist: 4.24.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite@5.4.11:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.27.3
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  viz.js@1.8.2: {}
+
+  which-boxed-primitive@1.0.2:
+    dependencies:
+      is-bigint: 1.0.4
+      is-boolean-object: 1.1.2
+      is-number-object: 1.0.7
+      is-string: 1.0.7
+      is-symbol: 1.0.4
+
+  which-builtin-type@1.1.4:
+    dependencies:
+      function.prototype.name: 1.1.6
+      has-tostringtag: 1.0.2
+      is-async-function: 2.0.0
+      is-date-object: 1.0.5
+      is-finalizationregistry: 1.0.2
+      is-generator-function: 1.0.10
+      is-regex: 1.1.4
+      is-weakref: 1.0.2
+      isarray: 2.0.5
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.2
+      which-typed-array: 1.1.15
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.3
+
+  which-typed-array@1.1.15:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.7
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yallist@3.1.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/pkg/topology/embed/frontend/src/App.css
+++ b/pkg/topology/embed/frontend/src/App.css
@@ -6,38 +6,3 @@
   font-size: 0.8rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}

--- a/pkg/topology/embed/frontend/src/App.css
+++ b/pkg/topology/embed/frontend/src/App.css
@@ -1,0 +1,43 @@
+#root {
+/*  max-width: 1280px;*/
+/*  margin: 0 auto;*/
+/*  padding: 2rem;*/
+/*  text-align: center;*/
+  font-size: 0.8rem;
+}
+
+.logo {
+  height: 6em;
+  padding: 1.5em;
+  will-change: filter;
+  transition: filter 300ms;
+}
+.logo:hover {
+  filter: drop-shadow(0 0 2em #646cffaa);
+}
+.logo.react:hover {
+  filter: drop-shadow(0 0 2em #61dafbaa);
+}
+
+@keyframes logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  a:nth-of-type(2) .logo {
+    animation: logo-spin infinite 20s linear;
+  }
+}
+
+.card {
+  padding: 2em;
+}
+
+.read-the-docs {
+  color: #888;
+}

--- a/pkg/topology/embed/frontend/src/App.tsx
+++ b/pkg/topology/embed/frontend/src/App.tsx
@@ -1,13 +1,16 @@
-import { useState, useCallback, useEffect } from 'react'
-import { fetchTopology, ComputeTopologyParams, fetchPeers, RPC } from '@/lib/api'
+import { useState, useCallback, useEffect, useRef, forwardRef } from 'react'
+import { fetchTopologyJSON, ComputeTopologyParams, fetchPeers, RPC } from '@/lib/api'
 import { Graphviz } from 'graphviz-react'
+import { GraphCanvas, GraphCanvasRef, InternalGraphPosition, layoutProvider, recommendLayout } from 'reagraph'
 import './App.css'
 
 function App() {
     const [params, setParams] = useState({})
-    const [dot, setDot] = useState('graph{}')
     const [peers, setPeers] = useState<RPC[]>([])
+    const [graph, setGraph] = useState({ nodes: [], edges: [] })
     const [selectedPeers, setSelectedPeers] = useState<{ [url: string]: boolean }>({})
+    const nodeRef = useRef(new Map<string, InternalGraphPosition>())
+    const graphRef = useRef<GraphCanvasRef | null>(null)
 
     useEffect(() => {
         (async function() {
@@ -17,19 +20,49 @@ function App() {
     }, [])
 
     const handleClick = useCallback(async () => {
-        const dot = await fetchTopology({
+        const graph = await fetchTopologyJSON({
             ...params,
             includeNodes: Object.keys(selectedPeers).filter(url => selectedPeers[url]),
         })
-        setDot(dot)
-    }, [params, selectedPeers, setDot, fetchTopology])
+        console.log('graph', graph)
 
-    console.log('dot', dot)
+        const nodes = graph.nodes.map(node => ({
+            id: node.id,
+            label: node.moniker,
+        }))
+
+        const edges = graph.conns.map(conn => ({
+            source: conn.from,
+            target: conn.to,
+            id: `${conn.from}-${conn.to}`,
+            label: ``,
+        }))
+
+        setGraph({ nodes, edges })
+    }, [params, selectedPeers, setGraph, fetchTopologyJSON])
+
+    useEffect(() => {
+        if (!graph || !graph.nodes || !graph.edges) {
+            return
+        }
+
+        // let { nodes, edges } = graph
+        // let layout = layoutProvider({ type: recommendLayout(nodes, edges) })
+        // for (let node of nodes) {
+        //     if (!nodeRef.current.has(node.id)) {
+        //         let pos = layout.getNodePosition(node.id)
+        //         nodeRef.current.set(node.id, pos)
+        //     }
+        // }
+    }, [graph])
+
+    let { nodes, edges } = graph
+    let layout = recommendLayout(nodes, edges)
 
     return (
         <>
-            <div style={{ display: 'flex', width: '100%' }}>
-                <div style={{ 'max-width': '300px', 'overflow-x': 'scroll' }}>
+            <div style={{ displayxxxx: 'flex', width: '100%', height: '100vh' }}>
+                <div style={{ width: '300px', height: '100vh', overflowX: 'scroll', position: 'absolute', top: 0, left: 0, zIndex: 9999, backgroundColor: '#242424' }}>
                     <button onClick={handleClick}>Generate</button>
                     <ul>
                         {peers.map(peer => (
@@ -45,10 +78,40 @@ function App() {
                         ))}
                     </ul>
                 </div>
-                <div>
-                    <Graphviz dot={dot} options={{ zoom: true, width: 1024, height: 1024 }} />
+                <div style={{ positionxxxx: 'relative', widthxxxx: '100%' }}>
+                    {/*<Graphviz dot={dot} options={{ zoom: true, width: 1024, height: 1024 }} />*/}
+                    <GraphCanvas
+                        ref={graphRef}
+                        nodes={nodes}
+                        edges={edges}
+                        draggable
+                        layoutOverrides={{
+                            getNodePosition: (id, nodePositionArgs) => {
+                                let idx = nodes.findIndex(node => node.id === id)
+                                console.log('idx', idx)
+                                if (idx === -1) {
+                                    idx = Math.random() * 100
+                                }
 
-                    <pre><code>{dot}</code></pre>
+                                const position = {
+                                    x: 25 * idx,
+                                    y: idx % 2 === 0 ? 0 : 50,
+                                    z: 1,
+                                }
+
+                                return nodeRef.current?.get(id) || (function() {
+                                    // This next bit is quite fraught -- do not modify unless you know what you're doing
+                                    nodeRef.current.set(id, { id, x: position.x, vx: position.x, y: position.y, vy: position.y, z: 1, links: [], data: null, index: idx })
+                                    return position
+                                })()
+                            },
+                        }}
+                        onNodeDragged={node => {
+                            nodeRef.current.set(node.id, node.position)
+                        }}
+                    />
+
+                    {/*<pre><code>{dot}</code></pre>*/}
                 </div>
             </div>
         </>

--- a/pkg/topology/embed/frontend/src/App.tsx
+++ b/pkg/topology/embed/frontend/src/App.tsx
@@ -1,94 +1,130 @@
 import { useState, useCallback, useEffect, useRef, forwardRef } from 'react'
-import { fetchTopologyJSON, ComputeTopologyParams, fetchPeers, RPC } from '@/lib/api'
-import { Graphviz } from 'graphviz-react'
-import { GraphCanvas, GraphCanvasRef, InternalGraphPosition, layoutProvider, recommendLayout } from 'reagraph'
+import { fetchTopologyJSON, ComputeTopologyParams, fetchPeers, JSONResponse, RPC, Conn } from '@/lib/api'
+import { GraphCanvas, GraphCanvasRef, InternalGraphNode, InternalGraphEdge, InternalGraphPosition, layoutProvider, recommendLayout, useSelection } from 'reagraph'
+import forceAtlas2 from 'graphology-layout-forceatlas2'
+import random from 'graphology-layout/random'
+import circular from 'graphology-layout/circular'
+import Graph from 'graphology'
+
 import './App.css'
 
 function App() {
     const [params, setParams] = useState({})
-    const [peers, setPeers] = useState<RPC[]>([])
-    const [graph, setGraph] = useState({ nodes: [], edges: [] })
-    const [selectedPeers, setSelectedPeers] = useState<{ [url: string]: boolean }>({})
+
+    const [graph, setGraph] = useState<{ nodes: InternalGraphNode[], edges: InternalGraphEdge[] }>({ nodes: [], edges: [] })
+    const [apiData, setAPIData] = useState<JSONResponse>({ nodes: [], conns: [] })
+    const [clickedEdges, setClickedEdges] = useState<Record<string, boolean>>({})
+    const [minBytesSec, setMinBytesSec] = useState(0)
     const nodeRef = useRef(new Map<string, InternalGraphPosition>())
     const graphRef = useRef<GraphCanvasRef | null>(null)
 
-    useEffect(() => {
-        (async function() {
-            let peers = await fetchPeers()
-            setPeers(peers)
-        })()
-    }, [])
-
-    const handleClick = useCallback(async () => {
+    const renderGraph = useCallback(async (selectedPeers: { [id: string]: boolean }, crawlDistance: number) => {
+        setMinBytesSec(minBytesSec)
         const graph = await fetchTopologyJSON({
             ...params,
+            crawlDistance,
+            minBytesSec,
             includeNodes: Object.keys(selectedPeers).filter(url => selectedPeers[url]),
         })
-        console.log('graph', graph)
-
-        const nodes = graph.nodes.map(node => ({
-            id: node.id,
-            label: node.moniker,
-        }))
-
-        const edges = graph.conns.map(conn => ({
-            source: conn.from,
-            target: conn.to,
-            id: `${conn.from}-${conn.to}`,
-            label: ``,
-        }))
-
-        setGraph({ nodes, edges })
-    }, [params, selectedPeers, setGraph, fetchTopologyJSON])
+        setAPIData(graph)
+    }, [params, fetchTopologyJSON, setAPIData, minBytesSec])
 
     useEffect(() => {
-        if (!graph || !graph.nodes || !graph.edges) {
-            return
+        let max = (apiData.conns || []).reduce((max, conn) => {
+            let total = conn.connectionStatus.send_monitor.avg_rate + conn.connectionStatus.recv_monitor.avg_rate
+            if (total > max) {
+                return total
+            }
+            return max
+        }, 0)
+
+        const nodes = (apiData.nodes || []).map(node => ({
+            id: node.id,
+            label: node.validatorMoniker !== '' ? node.validatorMoniker : node.moniker,
+            fill: node.validatorAddress !== '' ? 'red' : undefined,
+        }))
+
+        const edges = (apiData.conns || [])
+            .filter(conn => conn.connectionStatus.send_monitor.avg_rate + conn.connectionStatus.recv_monitor.avg_rate >= minBytesSec)
+            .map(conn => ({
+                source: conn.from,
+                target: conn.to,
+                id: `${conn.from}-${conn.to}`,
+                label: clickedEdges[`${conn.from}-${conn.to}`] ? `${humanizeBytes(conn.connectionStatus.send_monitor.avg_rate)}/s\n${humanizeBytes(conn.connectionStatus.recv_monitor.avg_rate)}/s` : '',
+                size: (conn.connectionStatus.send_monitor.avg_rate + conn.connectionStatus.recv_monitor.avg_rate) / max * 5,
+            }))
+
+        let copy = [...nodes]
+
+        let circleSizes = [10, 25, 50, 75, 130, 200, 350, 500]
+        let cohorts = []
+        let k = 0
+        for (let size of circleSizes) {
+            const graph = new Graph()
+            let i = 0
+            for (let node of copy) {
+                if (!graph.hasNode(node.id)) {
+                    graph.addNode(node.id)
+                    i++
+                }
+
+                if (i >= size) {
+                    copy = copy.slice(i)
+                    break
+                }
+            }
+            random.assign(graph)
+
+            let positions = circular(graph, { scale: size * (8-k) })
+            console.log(positions)
+
+            let j = 0
+            for (let id in positions) {
+                let position = positions[id]
+                nodeRef.current.set(id, { id, x: position.x, vx: position.x, y: position.y, vy: position.y, z: 1, links: [], data: null, index: j++ })
+            }
+            // for (let edge of edges) {
+            //     graph.addEdge(edge.source, edge.target)
+            // }
+            k++
         }
 
-        // let { nodes, edges } = graph
-        // let layout = layoutProvider({ type: recommendLayout(nodes, edges) })
-        // for (let node of nodes) {
-        //     if (!nodeRef.current.has(node.id)) {
-        //         let pos = layout.getNodePosition(node.id)
-        //         nodeRef.current.set(node.id, pos)
-        //     }
-        // }
-    }, [graph])
+        setGraph({ nodes, edges })
+    }, [apiData, clickedEdges, setGraph, minBytesSec])
 
     let { nodes, edges } = graph
-    let layout = recommendLayout(nodes, edges)
+
+    function onEdgeClick(edge: InternalGraphEdge) {
+        setClickedEdges({ ...clickedEdges, [edge.id]: !clickedEdges[edge.id] })
+    }
+
+    const {
+        selections,
+        actives,
+        onNodeClick,
+        onCanvasClick
+    } = useSelection({
+        ref: graphRef,
+        nodes: nodes,
+        edges: edges,
+        pathSelectionType: 'all'
+    })
 
     return (
         <>
-            <div style={{ displayxxxx: 'flex', width: '100%', height: '100vh' }}>
-                <div style={{ width: '300px', height: '100vh', overflowX: 'scroll', position: 'absolute', top: 0, left: 0, zIndex: 9999, backgroundColor: '#242424' }}>
-                    <button onClick={handleClick}>Generate</button>
-                    <ul>
-                        {peers.map(peer => (
-                            <li key={peer.url}>
-                                <nobr>
-                                    <input
-                                        type="checkbox"
-                                        checked={selectedPeers[peer.url]}
-                                        onChange={e => setSelectedPeers({ ...selectedPeers, [peer.url]: e.target.checked })} />
-                                    {peer.moniker} ({peer.url})
-                                </nobr>
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-                <div style={{ positionxxxx: 'relative', widthxxxx: '100%' }}>
-                    {/*<Graphviz dot={dot} options={{ zoom: true, width: 1024, height: 1024 }} />*/}
+            <div style={{ width: '100vw', height: '100vh' }}>
+                <Sidebar renderGraph={renderGraph} minBytesSec={minBytesSec} setMinBytesSec={setMinBytesSec} />
+                <div>
                     <GraphCanvas
                         ref={graphRef}
                         nodes={nodes}
                         edges={edges}
+                        labelType="all"
                         draggable
+                        layoutType='forceDirected2d'
                         layoutOverrides={{
                             getNodePosition: (id, nodePositionArgs) => {
                                 let idx = nodes.findIndex(node => node.id === id)
-                                console.log('idx', idx)
                                 if (idx === -1) {
                                     idx = Math.random() * 100
                                 }
@@ -109,13 +145,109 @@ function App() {
                         onNodeDragged={node => {
                             nodeRef.current.set(node.id, node.position)
                         }}
+                        onEdgeClick={onEdgeClick}
+                        selections={selections} actives={actives} onCanvasClick={onCanvasClick} onNodeClick={onNodeClick}
                     />
-
-                    {/*<pre><code>{dot}</code></pre>*/}
                 </div>
             </div>
         </>
     )
+}
+
+function Sidebar(props: {
+    minBytesSec: number,
+    setMinBytesSec: (x: number) => void,
+    renderGraph: (selectedPeers: { [id: string]: boolean }, crawlDistance: number) => void,
+}) {
+    const { renderGraph, minBytesSec, setMinBytesSec } = props
+    const [peers, setPeers] = useState<RPC[]>([])
+    const [selectedPeers, setSelectedPeers] = useState<{ [url: string]: boolean }>({})
+    const [sidebarOpen, setSidebarOpen] = useState(true)
+    const [filterText, setFilterText] = useState('')
+    const [crawlDistance, setCrawlDistance] = useState(1)
+
+    useEffect(() => {
+        (async function() {
+            let peers = await fetchPeers()
+            setPeers(peers)
+        })()
+    }, [])
+
+    const filteredPeers = peers.filter(peer =>
+        peer.moniker.toLowerCase().includes(filterText.toLowerCase()) ||
+        peer.id.toLowerCase().includes(filterText.toLowerCase()) ||
+        peer.url.toLowerCase().includes(filterText.toLowerCase())
+    )
+
+    return (
+        <>
+            <div style={{ width: sidebarOpen ? 'fit-content' : 0, height: '100vh', overflowX: 'scroll', position: 'absolute', top: 0, left: 0, zIndex: 9999, backgroundColor: '#242424' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <button style={{ margin: 8 }} onClick={() => renderGraph(selectedPeers, crawlDistance)}>Generate</button>
+                    <input
+                        type="text"
+                        placeholder="Filter peers..."
+                        value={filterText}
+                        onChange={(e) => setFilterText(e.target.value)}
+                        style={{ width: 'calc(100% - 88px)', height: '1rem', marginTop: 8, marginRight: 10, padding: '5px' }}
+                    />
+                    <input
+                        type="text"
+                        placeholder="Crawl..."
+                        value={crawlDistance}
+                        onChange={(e) => setCrawlDistance(Number(e.target.value))}
+                        style={{ width: 64, height: '1rem', marginTop: 8, marginRight: 10, padding: '5px' }}
+                    />
+                    <input
+                        type="text"
+                        placeholder="Min bytes/sec..."
+                        value={minBytesSec}
+                        onChange={(e) => setMinBytesSec(Number(e.target.value))}
+                        style={{ width: 128, height: '1rem', marginTop: 8, padding: '5px' }}
+                    />
+                    <button onClick={() => setSidebarOpen(false)} style={{ margin: 8, zIndex: 9 }}>Close</button>
+                </div>
+                <table>
+                    {filteredPeers.map(peer => (
+                        <tr key={peer.url}>
+                            <td>
+                                <input
+                                    type="checkbox"
+                                    checked={selectedPeers[peer.url]}
+                                    onChange={e => setSelectedPeers({ ...selectedPeers, [peer.url]: e.target.checked })} />
+                            </td>
+                            <td>{peer.moniker}</td>
+                            <td>{peer.id}</td>
+                            <td>{peer.url}</td>
+                        </tr>
+                    ))}
+                </table>
+            </div>
+            <button onClick={() => setSidebarOpen(true)} style={{ position: 'absolute', top: 16, left: 16, zIndex: 9 }}>Open sidebar</button>
+        </>
+    )
+}
+
+function humanizeBytes(bytes: number | string, si = true, dp = 1) {
+    bytes = Number(bytes)
+    const thresh = si ? 1000 : 1024
+
+    if (Math.abs(bytes) < thresh) {
+        return bytes + ' B'
+    }
+
+    const units = si
+        ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+        : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+    let u = -1
+    const r = 10**dp
+
+    do {
+        bytes /= thresh
+        ++u
+    } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1)
+
+    return bytes.toFixed(dp) + ' ' + units[u]
 }
 
 export default App

--- a/pkg/topology/embed/frontend/src/App.tsx
+++ b/pkg/topology/embed/frontend/src/App.tsx
@@ -1,0 +1,58 @@
+import { useState, useCallback, useEffect } from 'react'
+import { fetchTopology, ComputeTopologyParams, fetchPeers, RPC } from '@/lib/api'
+import { Graphviz } from 'graphviz-react'
+import './App.css'
+
+function App() {
+    const [params, setParams] = useState({})
+    const [dot, setDot] = useState('graph{}')
+    const [peers, setPeers] = useState<RPC[]>([])
+    const [selectedPeers, setSelectedPeers] = useState<{ [url: string]: boolean }>({})
+
+    useEffect(() => {
+        (async function() {
+            let peers = await fetchPeers()
+            setPeers(peers)
+        })()
+    }, [])
+
+    const handleClick = useCallback(async () => {
+        const dot = await fetchTopology({
+            ...params,
+            includeNodes: Object.keys(selectedPeers).filter(url => selectedPeers[url]),
+        })
+        setDot(dot)
+    }, [params, selectedPeers, setDot, fetchTopology])
+
+    console.log('dot', dot)
+
+    return (
+        <>
+            <div style={{ display: 'flex', width: '100%' }}>
+                <div style={{ 'max-width': '300px', 'overflow-x': 'scroll' }}>
+                    <button onClick={handleClick}>Generate</button>
+                    <ul>
+                        {peers.map(peer => (
+                            <li key={peer.url}>
+                                <nobr>
+                                    <input
+                                        type="checkbox"
+                                        checked={selectedPeers[peer.url]}
+                                        onChange={e => setSelectedPeers({ ...selectedPeers, [peer.url]: e.target.checked })} />
+                                    {peer.moniker} ({peer.url})
+                                </nobr>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+                <div>
+                    <Graphviz dot={dot} options={{ zoom: true, width: 1024, height: 1024 }} />
+
+                    <pre><code>{dot}</code></pre>
+                </div>
+            </div>
+        </>
+    )
+}
+
+export default App

--- a/pkg/topology/embed/frontend/src/index.css
+++ b/pkg/topology/embed/frontend/src/index.css
@@ -1,0 +1,68 @@
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
+}
+a:hover {
+  color: #535bf2;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+h1 {
+  font-size: 3.2em;
+  line-height: 1.1;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+button:hover {
+  border-color: #646cff;
+}
+button:focus,
+button:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}

--- a/pkg/topology/embed/frontend/src/index.css
+++ b/pkg/topology/embed/frontend/src/index.css
@@ -24,6 +24,7 @@ a:hover {
 
 body {
   margin: 0;
+  padding: 0;
   display: flex;
   place-items: center;
   min-width: 320px;
@@ -52,6 +53,11 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+
+#root {
+  width: 100vw;
+  height: 100vh;
 }
 
 @media (prefers-color-scheme: light) {

--- a/pkg/topology/embed/frontend/src/lib/api.ts
+++ b/pkg/topology/embed/frontend/src/lib/api.ts
@@ -1,10 +1,9 @@
 import queryString from 'query-string'
 
 export type ComputeTopologyParams = {
-    // currentHomeNode: string
     includeNodes?: string[]
     crawlDistance?: number
-    // highlightNodes?: string[]
+    minBytesSec?: number
 }
 
 export async function fetchTopologyDOT(params: ComputeTopologyParams): Promise<string> {
@@ -14,6 +13,7 @@ export async function fetchTopologyDOT(params: ComputeTopologyParams): Promise<s
         // currentHomeNode: params.currentHomeNode,
         includeNodes: params.includeNodes,
         crawlDistance: params.crawlDistance,
+        minBytesSec: params.minBytesSec,
         // highlightNodes: params.highlightNodes
         format: 'dot',
     })
@@ -34,12 +34,18 @@ export async function fetchTopologyDOT(params: ComputeTopologyParams): Promise<s
     return await response.text()
 }
 
-export async function fetchTopologyJSON(params: ComputeTopologyParams): Promise<any> {
+export type JSONResponse = {
+    nodes?: RPC[]
+    conns?: Conn[]
+}
+
+export async function fetchTopologyJSON(params: ComputeTopologyParams): Promise<JSONResponse> {
     params.crawlDistance = params.crawlDistance || 1
 
     const queryParams = queryString.stringify({
         includeNodes: params.includeNodes,
         crawlDistance: params.crawlDistance,
+        minBytesSec: params.minBytesSec,
     })
 
     const response = await fetch(`http://localhost:8080/topology?${queryParams}`, {
@@ -56,9 +62,25 @@ export async function fetchTopologyJSON(params: ComputeTopologyParams): Promise<
 }
 
 export type RPC = {
+    id: string
     ip: string
     url: string
     moniker: string
+    validatorAddress: string
+    validatorMoniker: string
+}
+
+export type Conn = {
+    from: string
+    to: string
+    connectionStatus: {
+        send_monitor: {
+            avg_rate: number
+        }
+        recv_monitor: {
+            avg_rate: number
+        }
+    }
 }
 
 export async function fetchPeers(): Promise<RPC[]> {

--- a/pkg/topology/embed/frontend/src/lib/api.ts
+++ b/pkg/topology/embed/frontend/src/lib/api.ts
@@ -7,7 +7,7 @@ export type ComputeTopologyParams = {
     // highlightNodes?: string[]
 }
 
-export async function fetchTopology(params: ComputeTopologyParams): Promise<string> {
+export async function fetchTopologyDOT(params: ComputeTopologyParams): Promise<string> {
     params.crawlDistance = params.crawlDistance || 1
 
     const queryParams = queryString.stringify({
@@ -15,6 +15,7 @@ export async function fetchTopology(params: ComputeTopologyParams): Promise<stri
         includeNodes: params.includeNodes,
         crawlDistance: params.crawlDistance,
         // highlightNodes: params.highlightNodes
+        format: 'dot',
     })
     console.log('params', params)
     console.log('queryParams', queryParams)
@@ -31,6 +32,27 @@ export async function fetchTopology(params: ComputeTopologyParams): Promise<stri
     }
 
     return await response.text()
+}
+
+export async function fetchTopologyJSON(params: ComputeTopologyParams): Promise<any> {
+    params.crawlDistance = params.crawlDistance || 1
+
+    const queryParams = queryString.stringify({
+        includeNodes: params.includeNodes,
+        crawlDistance: params.crawlDistance,
+    })
+
+    const response = await fetch(`http://localhost:8080/topology?${queryParams}`, {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json',
+        },
+    })
+
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+    }
+    return await response.json()
 }
 
 export type RPC = {

--- a/pkg/topology/embed/frontend/src/lib/api.ts
+++ b/pkg/topology/embed/frontend/src/lib/api.ts
@@ -1,0 +1,55 @@
+import queryString from 'query-string'
+
+export type ComputeTopologyParams = {
+    // currentHomeNode: string
+    includeNodes?: string[]
+    crawlDistance?: number
+    // highlightNodes?: string[]
+}
+
+export async function fetchTopology(params: ComputeTopologyParams): Promise<string> {
+    params.crawlDistance = params.crawlDistance || 1
+
+    const queryParams = queryString.stringify({
+        // currentHomeNode: params.currentHomeNode,
+        includeNodes: params.includeNodes,
+        crawlDistance: params.crawlDistance,
+        // highlightNodes: params.highlightNodes
+    })
+    console.log('params', params)
+    console.log('queryParams', queryParams)
+
+    const response = await fetch(`http://localhost:8080/topology?${queryParams}`, {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json',
+        },
+    })
+
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    return await response.text()
+}
+
+export type RPC = {
+    ip: string
+    url: string
+    moniker: string
+}
+
+export async function fetchPeers(): Promise<RPC[]> {
+    const response = await fetch('http://localhost:8080/peers', {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json',
+        },
+    })
+
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    return await response.json()
+}

--- a/pkg/topology/embed/frontend/src/main.tsx
+++ b/pkg/topology/embed/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/pkg/topology/embed/frontend/tsconfig.json
+++ b/pkg/topology/embed/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/pkg/topology/embed/frontend/vite.config.js
+++ b/pkg/topology/embed/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+})
+
+

--- a/pkg/topology/http.go
+++ b/pkg/topology/http.go
@@ -14,7 +14,7 @@ import (
 	"main/pkg/types"
 )
 
-func WithHTTPTopologyAPI(state *types.State, highlightNodes []string) tmhttp.Option {
+func WithHTTPTopologyAPI(state *types.State) tmhttp.Option {
 	return tmhttp.WithRoute("GET", "/topology", utils.UnrestrictedCors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ComputeTopologyRequest
 		err := utils.UnmarshalHTTPRequest(&req, r)

--- a/pkg/topology/http.go
+++ b/pkg/topology/http.go
@@ -1,0 +1,24 @@
+package topology
+
+import (
+	"fmt"
+	tmhttp "main/pkg/http"
+	"main/pkg/types"
+	"net/http"
+)
+
+func WithHTTPTopologyAPI(state *types.State) tmhttp.Option {
+	return tmhttp.WithRoute("GET", "/topology", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		topoGraph, err := ComputeTopology(state)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Could not compute topology: %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/vnd.graphviz")
+		if err := RenderTopology(topoGraph, w); err != nil {
+			http.Error(w, fmt.Sprintf("Could not render topology: %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}))
+}

--- a/pkg/topology/http.go
+++ b/pkg/topology/http.go
@@ -23,18 +23,52 @@ func WithHTTPTopologyAPI(state *types.State) tmhttp.Option {
 			return
 		}
 
-		topoGraph, err := ComputeTopology(state, req)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Could not compute topology: %s", err.Error()), http.StatusInternalServerError)
-			return
-		}
+		if req.Format == "dot" {
+			topoGraph, err := ComputeTopologyDOT(state, req)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Could not compute topology: %s", err.Error()), http.StatusInternalServerError)
+				return
+			}
 
-		w.Header().Set("Content-Type", "text/vnd.graphviz")
-		if err := RenderTopology(topoGraph, w); err != nil {
-			http.Error(w, fmt.Sprintf("Could not render topology: %s", err.Error()), http.StatusInternalServerError)
-			return
+			w.Header().Set("Content-Type", "text/vnd.graphviz")
+			if err := RenderTopologyDOT(topoGraph, w); err != nil {
+				http.Error(w, fmt.Sprintf("Could not render topology: %s", err.Error()), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			topoGraph, err := ComputeTopologyJSON(state, req)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Could not compute topology: %s", err.Error()), http.StatusInternalServerError)
+				return
+			}
+
+			if err := RenderTopologyJSON(topoGraph, w); err != nil {
+				http.Error(w, fmt.Sprintf("Could not render topology: %s", err.Error()), http.StatusInternalServerError)
+				return
+			}
 		}
 	})))
+
+	// return tmhttp.WithRoute("GET", "/topology", utils.UnrestrictedCors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// 	var req ComputeTopologyRequest
+	// 	err := utils.UnmarshalHTTPRequest(&req, r)
+	// 	if err != nil {
+	// 		http.Error(w, fmt.Sprintf("bad request: %s", err.Error()), http.StatusBadRequest)
+	// 		return
+	// 	}
+
+	// 	topoGraph, err := ComputeTopology(state, req)
+	// 	if err != nil {
+	// 		http.Error(w, fmt.Sprintf("Could not compute topology: %s", err.Error()), http.StatusInternalServerError)
+	// 		return
+	// 	}
+
+	// 	w.Header().Set("Content-Type", "text/vnd.graphviz")
+	// 	if err := RenderTopology(topoGraph, w); err != nil {
+	// 		http.Error(w, fmt.Sprintf("Could not render topology: %s", err.Error()), http.StatusInternalServerError)
+	// 		return
+	// 	}
+	// })))
 }
 
 func WithHTTPPeersAPI(state *types.State) tmhttp.Option {

--- a/pkg/topology/http.go
+++ b/pkg/topology/http.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 )
 
-func WithHTTPTopologyAPI(state *types.State) tmhttp.Option {
+func WithHTTPTopologyAPI(state *types.State, highlightNodes []string) tmhttp.Option {
 	return tmhttp.WithRoute("GET", "/topology", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		topoGraph, err := ComputeTopology(state)
+		topoGraph, err := ComputeTopology(state, highlightNodes)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Could not compute topology: %s", err.Error()), http.StatusInternalServerError)
 			return

--- a/pkg/topology/http.go
+++ b/pkg/topology/http.go
@@ -1,15 +1,29 @@
 package topology
 
 import (
+	"encoding/json"
 	"fmt"
-	tmhttp "main/pkg/http"
-	"main/pkg/types"
+	"io/fs"
 	"net/http"
+
+	"github.com/brynbellomy/go-utils"
+	"github.com/gorilla/mux"
+
+	tmhttp "main/pkg/http"
+	"main/pkg/topology/embed"
+	"main/pkg/types"
 )
 
 func WithHTTPTopologyAPI(state *types.State, highlightNodes []string) tmhttp.Option {
-	return tmhttp.WithRoute("GET", "/topology", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		topoGraph, err := ComputeTopology(state, highlightNodes)
+	return tmhttp.WithRoute("GET", "/topology", utils.UnrestrictedCors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ComputeTopologyRequest
+		err := utils.UnmarshalHTTPRequest(&req, r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("bad request: %s", err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		topoGraph, err := ComputeTopology(state, req)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Could not compute topology: %s", err.Error()), http.StatusInternalServerError)
 			return
@@ -20,5 +34,24 @@ func WithHTTPTopologyAPI(state *types.State, highlightNodes []string) tmhttp.Opt
 			http.Error(w, fmt.Sprintf("Could not render topology: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
-	}))
+	})))
+}
+
+func WithHTTPPeersAPI(state *types.State) tmhttp.Option {
+	return tmhttp.WithRoute("GET", "/peers", utils.UnrestrictedCors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peers := state.KnownRPCs().Values()
+		_ = json.NewEncoder(w).Encode(peers)
+	})))
+}
+
+func WithFrontendStaticAssets() tmhttp.Option {
+	return tmhttp.WithRouterOption(func(r *mux.Router) {
+		assets, err := fs.Sub(embed.Frontend, "frontend/dist")
+		if err != nil {
+			panic(err)
+		}
+		r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.FileServer(http.FS(assets)).ServeHTTP(w, r)
+		})
+	})
 }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -2,6 +2,8 @@ package topology
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
 	"main/pkg/types"
 
@@ -19,11 +21,12 @@ type ComputeTopologyRequest struct {
 	IncludeNodes    []string `query:"includeNodes"`
 	CrawlDistance   uint64   `query:"crawlDistance"`
 	HighlightNodes  []string `query:"highlightNodes"`
+	Format          string   `query:"format"`
 }
 
-func ComputeTopology(state *types.State, req ComputeTopologyRequest) (graph.Graph, error) {
+func ComputeTopologyDOT(state *types.State, req ComputeTopologyRequest) (graph.Graph, error) {
 	nodeIDs := make(map[string]int64)
-	var highlightedGraphNodes []*Node
+	var highlightedGraphNodes []*DOTPeerNode
 
 	knownRPCs := state.KnownRPCs()
 	includeNodes := utils.NewSet[types.RPC]()
@@ -44,15 +47,15 @@ func ComputeTopology(state *types.State, req ComputeTopologyRequest) (graph.Grap
 
 	// Render all known RPCs
 	for rpc := range includeNodes {
-		var node *Node
+		var node *DOTPeerNode
 		if highlightRPCs.Has(rpc.ID) || highlightRPCs.Has(rpc.IP) || highlightRPCs.Has(rpc.URL) || highlightRPCs.Has(rpc.Moniker) {
-			node = NewNode(g.NewNode(), rpc, "crimson")
+			node = NewDOTPeerNode(g.NewNode(), rpc, "crimson")
 			highlightedGraphNodes = append(highlightedGraphNodes, node)
 		} else {
-			node = NewNode(g.NewNode(), rpc, "cadetblue")
+			node = NewDOTPeerNode(g.NewNode(), rpc, "cadetblue")
 		}
 
-		nodeIDs[rpc.URL] = node.ID()
+		nodeIDs[rpc.URL] = node.Node.ID()
 		g.AddNode(node)
 	}
 
@@ -69,7 +72,7 @@ func ComputeTopology(state *types.State, req ComputeTopologyRequest) (graph.Grap
 			}
 
 			if g.Edge(nodeID1, nodeID2) == nil && g.Edge(nodeID2, nodeID1) == nil {
-				g.SetEdge(NewEdge(g.Node(nodeID1), g.Node(nodeID2), "azure4", "1.0"))
+				g.SetEdge(NewDOTEdge(g.Node(nodeID1), g.Node(nodeID2), "azure4", "1.0"))
 			}
 		}
 	}
@@ -83,14 +86,14 @@ func ComputeTopology(state *types.State, req ComputeTopologyRequest) (graph.Grap
 			}
 
 			for e := 0; e < len(npath)-1; e++ {
-				edge := g.Edge(npath[e].ID(), npath[e+1].ID()).(*Edge)
+				edge := g.Edge(npath[e].ID(), npath[e+1].ID()).(*DOTEdge)
 				if edge != nil {
 					edge.SetColor("crimson")
 					edge.SetWidth("3.0")
 				}
 
 				// hack: color the reverse path to make sure we don't color the "copied" reversed edge
-				edge = g.Edge(npath[e+1].ID(), npath[e].ID()).(*Edge)
+				edge = g.Edge(npath[e+1].ID(), npath[e].ID()).(*DOTEdge)
 				if edge != nil {
 					edge.SetColor("crimson")
 					edge.SetWidth("3.0")
@@ -124,12 +127,7 @@ func stackBasedCrawl(state *types.State, homeNode types.RPC, crawlDistance uint6
 
 		for _, peer := range state.RPCPeers(item.node.URL) {
 			stack = append(stack, stackItem{
-				node: types.RPC{
-					ID:      string(peer.NodeInfo.DefaultNodeID),
-					IP:      peer.RemoteIP,
-					URL:     "http://" + peer.RemoteIP + ":26657",
-					Moniker: peer.NodeInfo.Moniker,
-				},
+				node:  types.NewRPCFromPeer(peer),
 				depth: item.depth + 1,
 			})
 		}
@@ -137,7 +135,7 @@ func stackBasedCrawl(state *types.State, homeNode types.RPC, crawlDistance uint6
 	return visited
 }
 
-func RenderTopology(topology graph.Graph, w io.Writer) error {
+func RenderTopologyDOT(topology graph.Graph, w io.Writer) error {
 	raw, err := dot.Marshal(topology, "topology", "", "")
 	if err != nil {
 		return err
@@ -145,4 +143,45 @@ func RenderTopology(topology graph.Graph, w io.Writer) error {
 
 	_, err = bytes.NewReader(raw).WriteTo(w)
 	return err
+}
+
+func ComputeTopologyJSON(state *types.State, req ComputeTopologyRequest) (Graph, error) {
+	knownRPCs := state.KnownRPCs()
+	includeNodes := utils.NewSet[types.RPC]()
+
+	// Gather all nodes to include, factoring in the crawl distance
+	for _, url := range req.IncludeNodes {
+		rpc, ok := knownRPCs.Get(url)
+		LogChannel <- fmt.Sprintf("RPC %v %v", rpc.URL, ok)
+		if !ok {
+			continue
+		}
+		includeNodes.AddSet(stackBasedCrawl(state, rpc, req.CrawlDistance))
+	}
+
+	LogChannel <- fmt.Sprintf("INCLUDE %v", includeNodes)
+
+	var g Graph
+
+	// Add nodes
+	for rpc := range includeNodes {
+		g.Nodes = append(g.Nodes, rpc)
+	}
+
+	// Add edges
+	for rpc := range includeNodes {
+		for _, peer := range state.RPCPeers(rpc.URL) {
+			if peer.IsOutbound {
+				g.AddConn(rpc.ID, string(peer.NodeInfo.DefaultNodeID), peer.ConnectionStatus)
+			} else {
+				g.AddConn(string(peer.NodeInfo.DefaultNodeID), rpc.ID, peer.ConnectionStatus)
+			}
+		}
+	}
+
+	return g, nil
+}
+
+func RenderTopologyJSON(g Graph, w io.Writer) error {
+	return json.NewEncoder(w).Encode(g)
 }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -2,16 +2,15 @@ package topology
 
 import (
 	"bytes"
-	"encoding/json"
-	"fmt"
 	"io"
-	"main/pkg/types"
 
-	"github.com/brynbellomy/go-utils"
+	butils "github.com/brynbellomy/go-utils"
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding/dot"
 	"gonum.org/v1/gonum/graph/path"
 	"gonum.org/v1/gonum/graph/simple"
+
+	"main/pkg/types"
 )
 
 var LogChannel chan string
@@ -20,16 +19,15 @@ type ComputeTopologyRequest struct {
 	CurrentHomeNode string   `query:"currentHomeNode"`
 	IncludeNodes    []string `query:"includeNodes"`
 	CrawlDistance   uint64   `query:"crawlDistance"`
+	MinBytesSec     uint64   `query:"minBytesSec"`
 	HighlightNodes  []string `query:"highlightNodes"`
 	Format          string   `query:"format"`
 }
 
-func ComputeTopologyDOT(state *types.State, req ComputeTopologyRequest) (graph.Graph, error) {
-	nodeIDs := make(map[string]int64)
-	var highlightedGraphNodes []*DOTPeerNode
-
+func ComputeTopology(state *types.State, req ComputeTopologyRequest) (Graph, error) {
 	knownRPCs := state.KnownRPCs()
-	includeNodes := utils.NewSet[types.RPC]()
+	includeNodes := butils.NewSet[types.RPC]()
+	includeIDs := butils.NewSet[string]()
 
 	// Gather all nodes to include, factoring in the crawl distance
 	for _, url := range req.IncludeNodes {
@@ -37,16 +35,79 @@ func ComputeTopologyDOT(state *types.State, req ComputeTopologyRequest) (graph.G
 		if !ok {
 			continue
 		}
-		includeNodes.AddSet(stackBasedCrawl(state, rpc, req.CrawlDistance))
+		includeNodes.AddSet(stackBasedCrawl(state, rpc, req.CrawlDistance, req.MinBytesSec))
 	}
 
-	highlightRPCs := utils.NewSet[string]()
+	var g Graph
+
+	// Add nodes
+	for rpc := range includeNodes {
+		g.Nodes = append(g.Nodes, rpc)
+		includeIDs.Add(rpc.ID)
+	}
+
+	// Add edges
+	for rpc := range includeNodes {
+		for _, peer := range state.RPCPeers(rpc.URL) {
+			if !includeIDs.Has(string(peer.NodeInfo.DefaultNodeID)) {
+				continue
+			}
+
+			if peer.IsOutbound {
+				g.AddConn(rpc.ID, string(peer.NodeInfo.DefaultNodeID), peer.ConnectionStatus)
+			} else {
+				g.AddConn(string(peer.NodeInfo.DefaultNodeID), rpc.ID, peer.ConnectionStatus)
+			}
+		}
+	}
+
+	return g, nil
+}
+
+func stackBasedCrawl(state *types.State, homeNode types.RPC, crawlDistance uint64, minBytesSec uint64) butils.Set[types.RPC] {
+	visited := butils.NewSet[types.RPC]()
+	visited.Add(homeNode)
+
+	type stackItem struct {
+		node  types.RPC
+		depth uint64
+	}
+	stack := []stackItem{{node: homeNode, depth: 0}}
+
+	for len(stack) > 0 {
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		visited.Add(item.node)
+
+		if item.depth >= crawlDistance {
+			continue
+		}
+
+		for _, peer := range state.RPCPeers(item.node.URL) {
+			if uint64(peer.ConnectionStatus.SendMonitor.AvgRate)+uint64(peer.ConnectionStatus.RecvMonitor.AvgRate) < minBytesSec {
+				continue
+			}
+			stack = append(stack, stackItem{
+				node:  types.NewRPCFromPeer(peer),
+				depth: item.depth + 1,
+			})
+		}
+	}
+	return visited
+}
+
+func ComputeTopologyDOT(topology Graph, req ComputeTopologyRequest) (graph.Graph, error) {
+	nodeIDs := make(map[string]int64)
+	var highlightedGraphNodes []*DOTPeerNode
+
+	highlightRPCs := butils.NewSet[string]()
 	highlightRPCs.AddAll(req.HighlightNodes...)
 
 	g := simple.NewUndirectedGraph()
 
 	// Render all known RPCs
-	for rpc := range includeNodes {
+	for _, rpc := range topology.Nodes {
 		var node *DOTPeerNode
 		if highlightRPCs.Has(rpc.ID) || highlightRPCs.Has(rpc.IP) || highlightRPCs.Has(rpc.URL) || highlightRPCs.Has(rpc.Moniker) {
 			node = NewDOTPeerNode(g.NewNode(), rpc, "crimson")
@@ -59,21 +120,20 @@ func ComputeTopologyDOT(state *types.State, req ComputeTopologyRequest) (graph.G
 		g.AddNode(node)
 	}
 
-	for rpc := range includeNodes {
-		nodeID1, ok := nodeIDs[rpc.URL]
+	// Add edges
+	for _, conn := range topology.Conns {
+		nodeID1, ok := nodeIDs[conn.From]
 		if !ok {
 			continue
 		}
 
-		for _, peer := range state.RPCPeers(rpc.URL) {
-			nodeID2, ok := nodeIDs[peer.URL()]
-			if !ok {
-				continue
-			}
+		nodeID2, ok := nodeIDs[conn.To]
+		if !ok {
+			continue
+		}
 
-			if g.Edge(nodeID1, nodeID2) == nil && g.Edge(nodeID2, nodeID1) == nil {
-				g.SetEdge(NewDOTEdge(g.Node(nodeID1), g.Node(nodeID2), "azure4", "1.0"))
-			}
+		if g.Edge(nodeID1, nodeID2) == nil && g.Edge(nodeID2, nodeID1) == nil {
+			g.SetEdge(NewDOTEdge(g.Node(nodeID1), g.Node(nodeID2), "azure4", "1.0"))
 		}
 	}
 
@@ -105,36 +165,6 @@ func ComputeTopologyDOT(state *types.State, req ComputeTopologyRequest) (graph.G
 	return g, nil
 }
 
-func stackBasedCrawl(state *types.State, homeNode types.RPC, crawlDistance uint64) utils.Set[types.RPC] {
-	visited := utils.NewSet[types.RPC]()
-	visited.Add(homeNode)
-
-	type stackItem struct {
-		node  types.RPC
-		depth uint64
-	}
-	stack := []stackItem{{node: homeNode, depth: 0}}
-
-	for len(stack) > 0 {
-		item := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-
-		visited.Add(item.node)
-
-		if item.depth >= crawlDistance {
-			continue
-		}
-
-		for _, peer := range state.RPCPeers(item.node.URL) {
-			stack = append(stack, stackItem{
-				node:  types.NewRPCFromPeer(peer),
-				depth: item.depth + 1,
-			})
-		}
-	}
-	return visited
-}
-
 func RenderTopologyDOT(topology graph.Graph, w io.Writer) error {
 	raw, err := dot.Marshal(topology, "topology", "", "")
 	if err != nil {
@@ -143,45 +173,4 @@ func RenderTopologyDOT(topology graph.Graph, w io.Writer) error {
 
 	_, err = bytes.NewReader(raw).WriteTo(w)
 	return err
-}
-
-func ComputeTopologyJSON(state *types.State, req ComputeTopologyRequest) (Graph, error) {
-	knownRPCs := state.KnownRPCs()
-	includeNodes := utils.NewSet[types.RPC]()
-
-	// Gather all nodes to include, factoring in the crawl distance
-	for _, url := range req.IncludeNodes {
-		rpc, ok := knownRPCs.Get(url)
-		LogChannel <- fmt.Sprintf("RPC %v %v", rpc.URL, ok)
-		if !ok {
-			continue
-		}
-		includeNodes.AddSet(stackBasedCrawl(state, rpc, req.CrawlDistance))
-	}
-
-	LogChannel <- fmt.Sprintf("INCLUDE %v", includeNodes)
-
-	var g Graph
-
-	// Add nodes
-	for rpc := range includeNodes {
-		g.Nodes = append(g.Nodes, rpc)
-	}
-
-	// Add edges
-	for rpc := range includeNodes {
-		for _, peer := range state.RPCPeers(rpc.URL) {
-			if peer.IsOutbound {
-				g.AddConn(rpc.ID, string(peer.NodeInfo.DefaultNodeID), peer.ConnectionStatus)
-			} else {
-				g.AddConn(string(peer.NodeInfo.DefaultNodeID), rpc.ID, peer.ConnectionStatus)
-			}
-		}
-	}
-
-	return g, nil
-}
-
-func RenderTopologyJSON(g Graph, w io.Writer) error {
-	return json.NewEncoder(w).Encode(g)
 }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -5,6 +5,7 @@ import (
 	"golang.org/x/exp/slices"
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding/dot"
+	"gonum.org/v1/gonum/graph/path"
 	"gonum.org/v1/gonum/graph/simple"
 	"io"
 	"main/pkg/types"
@@ -42,7 +43,23 @@ func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, 
 				continue
 			}
 
-			g.SetEdge(NewEdge(g.Node(rpcID), g.Node(peerID), "azure4"))
+			g.SetEdge(NewEdge(g.Node(rpcID), g.Node(peerID), "azure4", "1.0"))
+		}
+	}
+
+	for i, n := range highlightedNodes {
+		paths := path.DijkstraFrom(n, g)
+		for j := i + 1; j < len(highlightedNodes); j++ {
+			npath, _ := paths.To(highlightedNodes[j].ID())
+			if npath == nil {
+				continue
+			}
+
+			for e := 0; e < len(npath)-1; e++ {
+				edge := g.Edge(npath[e].ID(), npath[e+1].ID()).(*Edge)
+				edge.SetColor("crimson")
+				edge.SetWidth("3.0")
+			}
 		}
 	}
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -1,0 +1,49 @@
+package topology
+
+import (
+	"bytes"
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding/dot"
+	"gonum.org/v1/gonum/graph/simple"
+	"io"
+	"main/pkg/types"
+)
+
+func ComputeTopology(state *types.State) (graph.Graph, error) {
+	nodeIDs := make(map[string]int64)
+	g := simple.NewUndirectedGraph()
+
+	for _, rpc := range state.KnownRPCs() {
+		node := NewNode(g.NewNode(), rpc, "cadetblue")
+		nodeIDs[rpc.URL] = node.ID()
+		g.AddNode(node)
+	}
+
+	for _, rpc := range state.KnownRPCs() {
+		rpcID, ok := nodeIDs[rpc.URL]
+		if !ok {
+			continue
+		}
+
+		for _, peer := range state.RPCPeers(rpc.URL) {
+			peerID, ok := nodeIDs[peer.URL()]
+			if !ok {
+				continue
+			}
+
+			g.SetEdge(NewEdge(g.Node(rpcID), g.Node(peerID), "azure4"))
+		}
+	}
+
+	return g, nil
+}
+
+func RenderTopology(topology graph.Graph, w io.Writer) error {
+	raw, err := dot.Marshal(topology, "topology", "", "")
+	if err != nil {
+		return err
+	}
+
+	_, err = bytes.NewReader(raw).WriteTo(w)
+	return err
+}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -63,6 +63,10 @@ func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, 
 				edge := g.Edge(npath[e].ID(), npath[e+1].ID()).(*Edge)
 				edge.SetColor("crimson")
 				edge.SetWidth("3.0")
+				// hack: color the reverse path to make sure we don't color the "copied" reversed edge
+				edge = g.Edge(npath[e+1].ID(), npath[e].ID()).(*Edge)
+				edge.SetColor("crimson")
+				edge.SetWidth("3.0")
 			}
 		}
 	}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -16,10 +16,12 @@ func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, 
 	var highlightedNodes []*Node
 	g := simple.NewUndirectedGraph()
 
+	// Render all known RPCs
 	for _, rpc := range state.KnownRPCs() {
 		var node *Node
+		// Highlight nodes matched by ID, IP, or moniker
 		if slices.ContainsFunc(highlightNodes, func(n string) bool {
-			return n == rpc.Moniker || n == rpc.IP
+			return n == rpc.ID || n == rpc.IP || n == rpc.Moniker
 		}) {
 			node = NewNode(g.NewNode(), rpc, "crimson")
 			highlightedNodes = append(highlightedNodes, node)
@@ -31,6 +33,7 @@ func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, 
 		g.AddNode(node)
 	}
 
+	// Render all edges between nodes
 	for _, rpc := range state.KnownRPCs() {
 		rpcID, ok := nodeIDs[rpc.URL]
 		if !ok {
@@ -47,6 +50,7 @@ func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, 
 		}
 	}
 
+	// Highlight the shortest paths between highlighted nodes
 	for i, n := range highlightedNodes {
 		paths := path.DijkstraFrom(n, g)
 		for j := i + 1; j < len(highlightedNodes); j++ {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -2,29 +2,52 @@ package topology
 
 import (
 	"bytes"
-	"golang.org/x/exp/slices"
+	"io"
+	"main/pkg/types"
+
+	"github.com/brynbellomy/go-utils"
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding/dot"
 	"gonum.org/v1/gonum/graph/path"
 	"gonum.org/v1/gonum/graph/simple"
-	"io"
-	"main/pkg/types"
 )
 
-func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, error) {
+var LogChannel chan string
+
+type ComputeTopologyRequest struct {
+	CurrentHomeNode string   `query:"currentHomeNode"`
+	IncludeNodes    []string `query:"includeNodes"`
+	CrawlDistance   uint64   `query:"crawlDistance"`
+	HighlightNodes  []string `query:"highlightNodes"`
+}
+
+func ComputeTopology(state *types.State, req ComputeTopologyRequest) (graph.Graph, error) {
 	nodeIDs := make(map[string]int64)
-	var highlightedNodes []*Node
+	var highlightedGraphNodes []*Node
+
+	knownRPCs := state.KnownRPCs()
+	includeNodes := utils.NewSet[types.RPC]()
+
+	// Gather all nodes to include, factoring in the crawl distance
+	for _, url := range req.IncludeNodes {
+		rpc, ok := knownRPCs.Get(url)
+		if !ok {
+			continue
+		}
+		includeNodes.AddSet(stackBasedCrawl(state, rpc, req.CrawlDistance))
+	}
+
+	highlightRPCs := utils.NewSet[string]()
+	highlightRPCs.AddAll(req.HighlightNodes...)
+
 	g := simple.NewUndirectedGraph()
 
 	// Render all known RPCs
-	for _, rpc := range state.KnownRPCs() {
+	for rpc := range includeNodes {
 		var node *Node
-		// Highlight nodes matched by ID, IP, or moniker
-		if slices.ContainsFunc(highlightNodes, func(n string) bool {
-			return n == rpc.ID || n == rpc.IP || n == rpc.Moniker
-		}) {
+		if highlightRPCs.Has(rpc.ID) || highlightRPCs.Has(rpc.IP) || highlightRPCs.Has(rpc.URL) || highlightRPCs.Has(rpc.Moniker) {
 			node = NewNode(g.NewNode(), rpc, "crimson")
-			highlightedNodes = append(highlightedNodes, node)
+			highlightedGraphNodes = append(highlightedGraphNodes, node)
 		} else {
 			node = NewNode(g.NewNode(), rpc, "cadetblue")
 		}
@@ -33,45 +56,85 @@ func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, 
 		g.AddNode(node)
 	}
 
-	// Render all edges between nodes
-	for _, rpc := range state.KnownRPCs() {
-		rpcID, ok := nodeIDs[rpc.URL]
+	for rpc := range includeNodes {
+		nodeID1, ok := nodeIDs[rpc.URL]
 		if !ok {
 			continue
 		}
 
 		for _, peer := range state.RPCPeers(rpc.URL) {
-			peerID, ok := nodeIDs[peer.URL()]
+			nodeID2, ok := nodeIDs[peer.URL()]
 			if !ok {
 				continue
 			}
 
-			g.SetEdge(NewEdge(g.Node(rpcID), g.Node(peerID), "azure4", "1.0"))
+			if g.Edge(nodeID1, nodeID2) == nil && g.Edge(nodeID2, nodeID1) == nil {
+				g.SetEdge(NewEdge(g.Node(nodeID1), g.Node(nodeID2), "azure4", "1.0"))
+			}
 		}
 	}
 
-	// Highlight the shortest paths between highlighted nodes
-	for i, n := range highlightedNodes {
+	for i, n := range highlightedGraphNodes {
 		paths := path.DijkstraFrom(n, g)
-		for j := i + 1; j < len(highlightedNodes); j++ {
-			npath, _ := paths.To(highlightedNodes[j].ID())
+		for j := i + 1; j < len(highlightedGraphNodes); j++ {
+			npath, _ := paths.To(highlightedGraphNodes[j].ID())
 			if npath == nil {
 				continue
 			}
 
 			for e := 0; e < len(npath)-1; e++ {
 				edge := g.Edge(npath[e].ID(), npath[e+1].ID()).(*Edge)
-				edge.SetColor("crimson")
-				edge.SetWidth("3.0")
+				if edge != nil {
+					edge.SetColor("crimson")
+					edge.SetWidth("3.0")
+				}
+
 				// hack: color the reverse path to make sure we don't color the "copied" reversed edge
 				edge = g.Edge(npath[e+1].ID(), npath[e].ID()).(*Edge)
-				edge.SetColor("crimson")
-				edge.SetWidth("3.0")
+				if edge != nil {
+					edge.SetColor("crimson")
+					edge.SetWidth("3.0")
+				}
 			}
 		}
 	}
 
 	return g, nil
+}
+
+func stackBasedCrawl(state *types.State, homeNode types.RPC, crawlDistance uint64) utils.Set[types.RPC] {
+	visited := utils.NewSet[types.RPC]()
+	visited.Add(homeNode)
+
+	type stackItem struct {
+		node  types.RPC
+		depth uint64
+	}
+	stack := []stackItem{{node: homeNode, depth: 0}}
+
+	for len(stack) > 0 {
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		visited.Add(item.node)
+
+		if item.depth >= crawlDistance {
+			continue
+		}
+
+		for _, peer := range state.RPCPeers(item.node.URL) {
+			stack = append(stack, stackItem{
+				node: types.RPC{
+					ID:      string(peer.NodeInfo.DefaultNodeID),
+					IP:      peer.RemoteIP,
+					URL:     "http://" + peer.RemoteIP + ":26657",
+					Moniker: peer.NodeInfo.Moniker,
+				},
+				depth: item.depth + 1,
+			})
+		}
+	}
+	return visited
 }
 
 func RenderTopology(topology graph.Graph, w io.Writer) error {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"bytes"
+	"golang.org/x/exp/slices"
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding/dot"
 	"gonum.org/v1/gonum/graph/simple"
@@ -9,12 +10,22 @@ import (
 	"main/pkg/types"
 )
 
-func ComputeTopology(state *types.State) (graph.Graph, error) {
+func ComputeTopology(state *types.State, highlightNodes []string) (graph.Graph, error) {
 	nodeIDs := make(map[string]int64)
+	var highlightedNodes []*Node
 	g := simple.NewUndirectedGraph()
 
 	for _, rpc := range state.KnownRPCs() {
-		node := NewNode(g.NewNode(), rpc, "cadetblue")
+		var node *Node
+		if slices.ContainsFunc(highlightNodes, func(n string) bool {
+			return n == rpc.Moniker || n == rpc.IP
+		}) {
+			node = NewNode(g.NewNode(), rpc, "crimson")
+			highlightedNodes = append(highlightedNodes, node)
+		} else {
+			node = NewNode(g.NewNode(), rpc, "cadetblue")
+		}
+
 		nodeIDs[rpc.URL] = node.ID()
 		g.AddNode(node)
 	}

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -8,20 +8,22 @@ import (
 
 type Node struct {
 	graph.Node
-	label, color string
+	moniker, id, url, color string
 }
 
 func NewNode(n graph.Node, rpc types.RPC, color string) *Node {
 	return &Node{
-		Node:  n,
-		label: rpc.Moniker + "\n(" + rpc.URL + ")",
-		color: color,
+		Node:    n,
+		moniker: rpc.Moniker,
+		id:      rpc.ID,
+		url:     rpc.URL,
+		color:   color,
 	}
 }
 
 func (n *Node) Attributes() []encoding.Attribute {
 	return []encoding.Attribute{
-		{Key: "label", Value: n.label},
+		{Key: "label", Value: n.moniker + "\n" + n.id + "\n(" + n.url + ")"},
 		{Key: "style", Value: "filled"},
 		{Key: "color", Value: n.color},
 	}

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -1,0 +1,63 @@
+package topology
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding"
+	"main/pkg/types"
+)
+
+type Node struct {
+	graph.Node
+	label, color string
+}
+
+func NewNode(n graph.Node, rpc types.RPC, color string) *Node {
+	return &Node{
+		Node:  n,
+		label: rpc.Moniker + "\n(" + rpc.URL + ")",
+		color: color,
+	}
+}
+
+func (n *Node) Attributes() []encoding.Attribute {
+	return []encoding.Attribute{
+		{Key: "label", Value: n.label},
+		{Key: "style", Value: "filled"},
+		{Key: "color", Value: n.color},
+	}
+}
+
+type Edge struct {
+	from, to graph.Node
+	color    string
+}
+
+func NewEdge(from, to graph.Node, color string) *Edge {
+	return &Edge{
+		from:  from,
+		to:    to,
+		color: color,
+	}
+}
+
+func (e *Edge) From() graph.Node {
+	return e.from
+}
+
+func (e *Edge) To() graph.Node {
+	return e.to
+}
+
+func (e *Edge) ReversedEdge() graph.Edge {
+	return &Edge{from: e.to, to: e.from, color: e.color}
+}
+
+func (e *Edge) SetColor(color string) {
+	e.color = color
+}
+
+func (e *Edge) Attributes() []encoding.Attribute {
+	return []encoding.Attribute{
+		{Key: "color", Value: e.color},
+	}
+}

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -28,15 +28,16 @@ func (n *Node) Attributes() []encoding.Attribute {
 }
 
 type Edge struct {
-	from, to graph.Node
-	color    string
+	from, to     graph.Node
+	color, width string
 }
 
-func NewEdge(from, to graph.Node, color string) *Edge {
+func NewEdge(from, to graph.Node, color string, width string) *Edge {
 	return &Edge{
 		from:  from,
 		to:    to,
 		color: color,
+		width: width,
 	}
 }
 
@@ -56,8 +57,17 @@ func (e *Edge) SetColor(color string) {
 	e.color = color
 }
 
+func (e *Edge) SetWidth(width string) {
+	e.width = width
+}
+
+func (e *Edge) Weight() float64 {
+	return 1.0
+}
+
 func (e *Edge) Attributes() []encoding.Attribute {
 	return []encoding.Attribute{
 		{Key: "color", Value: e.color},
+		{Key: "penwidth", Value: e.width},
 	}
 }

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -1,41 +1,78 @@
 package topology
 
 import (
+	"main/pkg/types"
+
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
-	"main/pkg/types"
 )
 
-type Node struct {
+type Graph struct {
+	Nodes []types.RPC `json:"nodes"`
+	Conns []Conn      `json:"conns"`
+
+	connsMap map[string]bool
+}
+
+func (g *Graph) AddConn(from, to string, connectionStatus types.ConnectionStatus) {
+	if g.connsMap == nil {
+		g.connsMap = make(map[string]bool)
+	}
+
+	_, ok := g.connsMap[from+to]
+	if !ok {
+		g.Conns = append(g.Conns, NewConn(from, to, connectionStatus))
+		g.connsMap[from+to] = true
+	}
+}
+
+type Conn struct {
+	From             string                 `json:"from"`
+	To               string                 `json:"to"`
+	ConnectionStatus types.ConnectionStatus `json:"connectionStatus"`
+}
+
+func NewConn(from, to string, connectionStatus types.ConnectionStatus) Conn {
+	return Conn{
+		From:             from,
+		To:               to,
+		ConnectionStatus: connectionStatus,
+	}
+}
+
+type DOTPeerNode struct {
 	graph.Node
-	moniker, id, url, color string
+	types.RPC
+	Color string
 }
 
-func NewNode(n graph.Node, rpc types.RPC, color string) *Node {
-	return &Node{
-		Node:    n,
-		moniker: rpc.Moniker,
-		id:      rpc.ID,
-		url:     rpc.URL,
-		color:   color,
+func NewDOTPeerNode(n graph.Node, rpc types.RPC, color string) *DOTPeerNode {
+	return &DOTPeerNode{
+		Node:  n,
+		RPC:   rpc,
+		Color: color,
 	}
 }
 
-func (n *Node) Attributes() []encoding.Attribute {
+func (n *DOTPeerNode) ID() int64 {
+	return n.Node.ID()
+}
+
+func (n *DOTPeerNode) Attributes() []encoding.Attribute {
 	return []encoding.Attribute{
-		{Key: "label", Value: n.moniker + "\n" + n.id + "\n(" + n.url + ")"},
+		{Key: "label", Value: n.Moniker + "\n" + n.RPC.ID + "\n(" + n.URL + ")"},
 		{Key: "style", Value: "filled"},
-		{Key: "color", Value: n.color},
+		{Key: "color", Value: n.Color},
 	}
 }
 
-type Edge struct {
+type DOTEdge struct {
 	from, to     graph.Node
 	color, width string
 }
 
-func NewEdge(from, to graph.Node, color string, width string) *Edge {
-	return &Edge{
+func NewDOTEdge(from, to graph.Node, color string, width string) *DOTEdge {
+	return &DOTEdge{
 		from:  from,
 		to:    to,
 		color: color,
@@ -43,31 +80,31 @@ func NewEdge(from, to graph.Node, color string, width string) *Edge {
 	}
 }
 
-func (e *Edge) From() graph.Node {
+func (e *DOTEdge) From() graph.Node {
 	return e.from
 }
 
-func (e *Edge) To() graph.Node {
+func (e *DOTEdge) To() graph.Node {
 	return e.to
 }
 
-func (e *Edge) ReversedEdge() graph.Edge {
-	return &Edge{from: e.to, to: e.from, color: e.color, width: e.width}
+func (e *DOTEdge) ReversedEdge() graph.Edge {
+	return &DOTEdge{from: e.to, to: e.from, color: e.color, width: e.width}
 }
 
-func (e *Edge) SetColor(color string) {
+func (e *DOTEdge) SetColor(color string) {
 	e.color = color
 }
 
-func (e *Edge) SetWidth(width string) {
+func (e *DOTEdge) SetWidth(width string) {
 	e.width = width
 }
 
-func (e *Edge) Weight() float64 {
+func (e *DOTEdge) Weight() float64 {
 	return 1.0
 }
 
-func (e *Edge) Attributes() []encoding.Attribute {
+func (e *DOTEdge) Attributes() []encoding.Attribute {
 	return []encoding.Attribute{
 		{Key: "color", Value: e.color},
 		{Key: "penwidth", Value: e.width},

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -52,7 +52,7 @@ func (e *Edge) To() graph.Node {
 }
 
 func (e *Edge) ReversedEdge() graph.Edge {
-	return &Edge{from: e.to, to: e.from, color: e.color}
+	return &Edge{from: e.to, to: e.from, color: e.color, width: e.width}
 }
 
 func (e *Edge) SetColor(color string) {

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Graph struct {
-	Nodes []types.RPC `json:"nodes"`
-	Conns []Conn      `json:"conns"`
+	Nodes      []types.RPC                `json:"nodes"`
+	Conns      []Conn                     `json:"conns"`
+	Validators map[string]types.Validator `json:"validators"`
 
 	connsMap map[string]bool
 }

--- a/pkg/types/chain_validator.go
+++ b/pkg/types/chain_validator.go
@@ -6,6 +6,7 @@ type ChainValidator struct {
 	RawAddress         string
 	AssignedAddress    string
 	RawAssignedAddress string
+	ConsensusPubkey    []byte
 }
 
 type ChainValidators []ChainValidator

--- a/pkg/types/net_info.go
+++ b/pkg/types/net_info.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"reflect"
 	"strconv"
 	"time"
@@ -25,7 +26,11 @@ type Peer struct {
 }
 
 func (p Peer) URL() string {
-	return "http://" + p.RemoteIP + ":26657"
+	u, err := url.Parse(p.NodeInfo.Other.RPCAddress)
+	if err != nil {
+		return "http://" + p.RemoteIP + ":26657"
+	}
+	return "http" + "://" + p.RemoteIP + ":" + u.Port()
 }
 
 type DefaultNodeInfo struct {

--- a/pkg/types/net_info.go
+++ b/pkg/types/net_info.go
@@ -61,34 +61,34 @@ type ProtocolVersion struct {
 type ID string
 
 type ConnectionStatus struct {
-	Duration    NanoDuration
-	SendMonitor FlowStatus
-	RecvMonitor FlowStatus
-	Channels    []ChannelStatus
+	Duration    NanoDuration    `json:"duration"`
+	SendMonitor FlowStatus      `json:"send_monitor"`
+	RecvMonitor FlowStatus      `json:"recv_monitor"`
+	Channels    []ChannelStatus `json:"channels"`
 }
 
 type ChannelStatus struct {
-	ID                byte
-	SendQueueCapacity string
-	SendQueueSize     string
-	Priority          string
-	RecentlySent      string
+	ID                byte   `json:"id"`
+	SendQueueCapacity string `json:"send_queue_capacity"`
+	SendQueueSize     string `json:"send_queue_size"`
+	Priority          string `json:"priority"`
+	RecentlySent      string `json:"recently_sent"`
 }
 
 type FlowStatus struct {
-	Start    CustomTime   // Transfer start time
-	Bytes    ByteSize     // Total number of bytes transferred
-	Samples  ByteSize     // Total number of samples taken
-	InstRate ByteSize     // Instantaneous transfer rate
-	CurRate  ByteSize     // Current transfer rate (EMA of InstRate)
-	AvgRate  ByteSize     // Average transfer rate (Bytes / Duration)
-	PeakRate ByteSize     // Maximum instantaneous transfer rate
-	BytesRem ByteSize     // Number of bytes remaining in the transfer
-	Duration NanoDuration // Time period covered by the statistics
-	Idle     NanoDuration // Time since the last transfer of at least 1 byte
-	TimeRem  NanoDuration // Estimated time to completion
-	Progress Percent      // Overall transfer progress
-	Active   bool         // Flag indicating an active transfer
+	Start    CustomTime   `json:"start"`     // Transfer start time
+	Bytes    ByteSize     `json:"bytes"`     // Total number of bytes transferred
+	Samples  ByteSize     `json:"samples"`   // Total number of samples taken
+	InstRate ByteSize     `json:"inst_rate"` // Instantaneous transfer rate
+	CurRate  ByteSize     `json:"cur_rate"`  // Current transfer rate (EMA of InstRate)
+	AvgRate  ByteSize     `json:"avg_rate"`  // Average transfer rate (Bytes / Duration)
+	PeakRate ByteSize     `json:"peak_rate"` // Maximum instantaneous transfer rate
+	BytesRem ByteSize     `json:"bytes_rem"` // Number of bytes remaining in the transfer
+	Duration NanoDuration `json:"duration"`  // Time period covered by the statistics
+	Idle     NanoDuration `json:"idle"`      // Time since the last transfer of at least 1 byte
+	TimeRem  NanoDuration `json:"time_rem"`  // Estimated time to completion
+	Progress Percent      `json:"progress"`  // Overall transfer progress
+	Active   bool         `json:"active"`    // Flag indicating an active transfer
 }
 
 type NanoDuration time.Duration

--- a/pkg/types/net_info.go
+++ b/pkg/types/net_info.go
@@ -24,6 +24,10 @@ type Peer struct {
 	RemoteIP         string           `mapstructure:"remote_ip"`
 }
 
+func (p Peer) URL() string {
+	return "http://" + p.RemoteIP + ":26657"
+}
+
 type DefaultNodeInfo struct {
 	ProtocolVersion ProtocolVersion `mapstructure:"protocol_version"`
 

--- a/pkg/types/state.go
+++ b/pkg/types/state.go
@@ -35,13 +35,14 @@ type State struct {
 }
 
 type RPC struct {
+	IP      string
 	URL     string
 	Moniker string
 }
 
 func NewState(firstRPC string) *State {
 	knownRPCs := utils.NewOrderedMap[string, RPC]()
-	knownRPCs.Set(firstRPC, RPC{firstRPC, ""})
+	knownRPCs.Set(firstRPC, RPC{"", firstRPC, ""})
 	return &State{
 		Height:          0,
 		Round:           0,

--- a/pkg/types/state.go
+++ b/pkg/types/state.go
@@ -35,10 +35,10 @@ type State struct {
 }
 
 type RPC struct {
-	ID      string
-	IP      string
-	URL     string
-	Moniker string
+	ID      string `json:"id"`
+	IP      string `json:"ip"`
+	URL     string `json:"url"`
+	Moniker string `json:"moniker"`
 }
 
 func NewRPCFromPeer(peer Peer) RPC {
@@ -103,11 +103,11 @@ func (s *State) SetCurrentRPCURL(rpcURL string) {
 	s.currentRPC = rpcURL
 }
 
-func (s *State) KnownRPCs() []RPC {
+func (s *State) KnownRPCs() *utils.OrderedMap[string, RPC] {
 	s.muRPCs.RLock()
 	defer s.muRPCs.RUnlock()
 
-	return s.knownRPCs.Values()
+	return s.knownRPCs.Copy()
 }
 
 func (s *State) AddKnownRPC(rpc RPC) {
@@ -141,8 +141,8 @@ func (s *State) AddRPCPeers(rpcURL string, peers []Peer) {
 }
 
 func (s *State) RPCPeers(rpcURL string) []Peer {
-	s.muRPCs.Lock()
-	defer s.muRPCs.Unlock()
+	s.muRPCs.RLock()
+	defer s.muRPCs.RUnlock()
 
 	peers, _ := s.rpcPeers.Get(rpcURL)
 	return peers

--- a/pkg/types/state.go
+++ b/pkg/types/state.go
@@ -24,6 +24,7 @@ type State struct {
 
 	currentRPC string
 	knownRPCs  *utils.OrderedMap[string, RPC]
+	rpcPeers   *utils.OrderedMap[string, []Peer]
 	muRPCs     *sync.RWMutex
 
 	ConsensusStateError  error
@@ -51,6 +52,7 @@ func NewState(firstRPC string) *State {
 		BlockTime:       0,
 		currentRPC:      firstRPC,
 		knownRPCs:       knownRPCs,
+		rpcPeers:        utils.NewOrderedMap[string, []Peer](),
 		muRPCs:          &sync.RWMutex{},
 	}
 }
@@ -117,6 +119,21 @@ func (s *State) RPCAtIndex(index int) (RPC, bool) {
 
 	_, rpc, ok := s.knownRPCs.GetByIndex(index)
 	return rpc, ok
+}
+
+func (s *State) AddRPCPeers(rpcURL string, peers []Peer) {
+	s.muRPCs.Lock()
+	defer s.muRPCs.Unlock()
+
+	s.rpcPeers.Set(rpcURL, peers)
+}
+
+func (s *State) RPCPeers(rpcURL string) []Peer {
+	s.muRPCs.Lock()
+	defer s.muRPCs.Unlock()
+
+	peers, _ := s.rpcPeers.Get(rpcURL)
+	return peers
 }
 
 func (s *State) SetTendermintResponse(

--- a/pkg/types/status.go
+++ b/pkg/types/status.go
@@ -5,7 +5,8 @@ type TendermintStatusResponse struct {
 }
 
 type TendermintStatusResult struct {
-	NodeInfo TendermintNodeInfo `json:"node_info"`
+	NodeInfo      TendermintNodeInfo      `json:"node_info"`
+	ValidatorInfo TendermintValidatorInfo `json:"validator_info"`
 }
 
 type TendermintNodeInfo struct {

--- a/pkg/types/status.go
+++ b/pkg/types/status.go
@@ -9,6 +9,16 @@ type TendermintStatusResult struct {
 }
 
 type TendermintNodeInfo struct {
+	ID      string `json:"id"`
 	Version string `json:"version"`
 	Network string `json:"network"`
+	Moniker string `json:"moniker"`
+	Other   struct {
+		RPCAddress string `json:"rpc_address"`
+	} `json:"other"`
+}
+
+type TendermintValidatorInfo struct {
+	Address     string `json:"address"`
+	VotingPower string `json:"voting_power"`
 }

--- a/pkg/types/tendermint_validator.go
+++ b/pkg/types/tendermint_validator.go
@@ -17,6 +17,12 @@ type ValidatorsResult struct {
 }
 
 type TendermintValidator struct {
-	Address     string `json:"address"`
-	VotingPower string `json:"voting_power"`
+	Address     string                    `json:"address"`
+	VotingPower string                    `json:"voting_power"`
+	PubKey      TendermintValidatorPubKey `json:"pub_key"`
+}
+
+type TendermintValidatorPubKey struct {
+	Type         string `json:"type"`
+	PubKeyBase64 string `json:"value"`
 }

--- a/pkg/types/validator.go
+++ b/pkg/types/validator.go
@@ -5,6 +5,8 @@ import (
 	"main/pkg/utils"
 	"math/big"
 	"strconv"
+
+	"github.com/cometbft/cometbft/p2p"
 )
 
 type Validator struct {
@@ -12,6 +14,8 @@ type Validator struct {
 	Address            string
 	VotingPower        *big.Int
 	VotingPowerPercent *big.Float
+	PubKey             []byte
+	PeerID             p2p.ID
 }
 
 type Validators []Validator

--- a/pkg/utils/ordered_map.go
+++ b/pkg/utils/ordered_map.go
@@ -85,6 +85,16 @@ func (m *OrderedMap[K, V]) String() string {
 	return sb.String()
 }
 
+func (m *OrderedMap[K, V]) Iter() func(func(k K, v V) bool) {
+	return func(yield func(k K, v V) bool) {
+		for _, k := range m.keys {
+			if !yield(k, m.values[k]) {
+				return
+			}
+		}
+	}
+}
+
 // Range iterates over the map in order, calling the given function for each key-value pair
 func (m *OrderedMap[K, V]) Range(f func(key K, value V)) {
 	for _, key := range m.keys {
@@ -111,4 +121,12 @@ func (m *OrderedMap[K, V]) GetByIndex(index int) (K, V, bool) {
 	}
 	key := m.keys[index]
 	return key, m.values[key], true
+}
+
+func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
+	newMap := NewOrderedMap[K, V]()
+	for _, key := range m.keys {
+		newMap.Set(key, m.values[key])
+	}
+	return newMap
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,7 +8,27 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcutil/bech32"
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	comet_secp256k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
+
+func PubKeyToPeerID(pubKeyBytes string) (string, error) {
+	// Convert to ed25519 public key
+	pubKey := make(ed25519.PubKey, ed25519.PubKeySize)
+	copy(pubKey[:], pubKeyBytes)
+
+	// Get the peer ID from the public key
+	peerID := crypto.Address(pubKey).String()
+	return peerID, nil
+}
+
+func ValidatorAddr(pubkeyBytes []byte) string {
+	pubkey := comet_secp256k1.PubKey(pubkeyBytes)
+	pubKeyConvertedToAddress := sdk.ValAddress(pubkey.Address().Bytes())
+	return pubKeyConvertedToAddress.String()
+}
 
 func MustParseInt64(source string) int64 {
 	result, err := strconv.ParseInt(source, 10, 64)


### PR DESCRIPTION
Integrate an HTTP server serving network topology related content.

## 🔍 Details

### State changes

When crawling RPCs to find new nodes in the network the direct peers from a node are kept in an in-memory map.

### Topology processing

The composition of the graph is made using https://github.com/gonum/gonum which supports some usual operations on a graph and its DOT marshalling.

The creation of graph nodes is made by navigating through the known RPCs displaying their moniker, node id and URLs. The edges are then drawn using the direct peers.

In order to control the output the computation takes the following _request_:
```go
type ComputeTopologyRequest struct {
	CurrentHomeNode string   `query:"currentHomeNode"`
	IncludeNodes    []string `query:"includeNodes"`
	CrawlDistance   uint64   `query:"crawlDistance"`
	HighlightNodes  []string `query:"highlightNodes"`
}
```

#### Highlighting **the Clique**

In order to emphasize the `ComputeTopologyRequest. HighlightNodes ` allow to provide a list of _highlighted_ node that can be targeted by either node id, url or moniker.

Those _highlighted_ nodes are rendered in a different color, and the shortest paths between them are also rendered differently.

### HTTP Server

In order to serve this topology a minimal http server has been added serving the following endpoints:
- `GET /topology`: the network topology in the [DOT language](https://graphviz.org/doc/info/lang.html), it accepts as query params the `ComputeTopologyRequest ` fields;
- `GET /peers`: All the known peers informations;
- `GET /*`: A front-end to explore the topology;

## 🎮 Usage

To configure this topology feature here are some options added to the CLI:
```
--with-topology-api                  Enable topology API
--topology-listen-addr string        The address on which to serve topology API (default "0.0.0.0:8080")
```

Here's an example play with it:
```bash
tmtop https://allora-rpc.testnet.allora.network --with-topology-api \
    --topology-listen-addr 127.0.0.1:8080
```

And here's how to use it (you may need to install [Graphviz](https://graphviz.org/download/)):
```bash
# Fetch the dot encoded graph
curl -s localhost:8080/topology

# Fetch and render in SVG
curl -s localhost:8080/topology | dot -Kdot -Tsvg -otopo.svg

# Fetch and render in PNG
curl -s localhost:8080/topology | dot -Kdot -Tpng -otopo.png
```

Or just visit `http://localhost:8080/` in a browser to access the front-end.